### PR TITLE
Fix HACS validation errors

### DIFF
--- a/HACS_TOPICS_SETUP.md
+++ b/HACS_TOPICS_SETUP.md
@@ -1,0 +1,54 @@
+# HACS Repository Topics Setup
+
+To complete HACS validation, the following topics need to be added to the GitHub repository:
+
+## Required Topics
+
+Add these topics to the repository via GitHub web interface:
+
+1. Go to https://github.com/craibo/ha-red-energy-au
+2. Click the gear icon next to "About" on the right side
+3. Add the following topics in the "Topics" field:
+
+### Core Topics
+- `home-assistant`
+- `homeassistant` 
+- `custom-component`
+- `integration`
+
+### Domain-Specific Topics
+- `energy`
+- `australia`
+- `red-energy`
+- `python`
+
+## How to Add Topics
+
+1. **Via GitHub Web Interface:**
+   - Navigate to repository main page
+   - Click settings gear next to "About" section
+   - Add topics separated by spaces or commas
+   - Save changes
+
+2. **Via GitHub CLI (if authenticated):**
+   ```bash
+   gh repo edit --add-topic "home-assistant" --add-topic "homeassistant" --add-topic "custom-component" --add-topic "integration" --add-topic "energy" --add-topic "australia" --add-topic "red-energy" --add-topic "python"
+   ```
+
+## HACS Validation Requirements
+
+- Repository must have topics defined
+- hacs.json must only contain valid keys:
+  - ✅ `name` (required)
+  - ✅ `country` (optional)
+  - ✅ `homeassistant` (optional - minimum HA version)
+  - ❌ `domains` (not allowed in hacs.json)
+  - ❌ `iot_class` (not allowed in hacs.json)
+
+## After Adding Topics
+
+1. The repository will pass HACS topic validation
+2. HACS validation workflow should pass
+3. Integration will be eligible for HACS inclusion
+
+Delete this file after topics have been added manually.

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -132,7 +132,7 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
                             "Fetched %s usage data for property %s: %s total usage",
                             service_type,
                             property_id,
-                            service_usage.get("total_usage", 0)
+                            validated_usage.get("total_usage", 0)
                         )
                         
                     except (RedEnergyAPIError, DataValidationError) as err:

--- a/custom_components/red_energy/services.yaml
+++ b/custom_components/red_energy/services.yaml
@@ -1,0 +1,54 @@
+refresh_data:
+  name: Refresh data
+  description: Manually refresh Red Energy usage data for all configured integrations.
+  fields: {}
+
+update_credentials:
+  name: Update credentials
+  description: Update Red Energy API credentials for authentication.
+  fields:
+    username:
+      name: Username
+      description: Red Energy account email address.
+      required: true
+      example: "user@example.com"
+      selector:
+        text:
+          type: email
+    password:
+      name: Password
+      description: Red Energy account password.
+      required: true
+      selector:
+        text:
+          type: password
+    client_id:
+      name: Client ID
+      description: Client ID captured from Red Energy mobile app.
+      required: true
+      example: "0oa1a2b3c4d5e6f7g8h9"
+      selector:
+        text:
+
+export_data:
+  name: Export data
+  description: Export Red Energy usage data in JSON or CSV format.
+  fields:
+    format:
+      name: Export format
+      description: Data export format.
+      default: "json"
+      selector:
+        select:
+          options:
+            - "json"
+            - "csv"
+    days:
+      name: Days
+      description: Number of days of data to export (1-365).
+      default: 30
+      selector:
+        number:
+          min: 1
+          max: 365
+          mode: box

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
   "name": "Red Energy",
   "country": ["AU"],
-  "domains": ["sensor"],
-  "iot_class": "Cloud Polling",
   "homeassistant": "2024.1.0"
 }


### PR DESCRIPTION
Remove invalid keys from hacs.json that caused validation failures:
- Remove 'domains' key (not allowed in hacs.json)
- Remove 'iot_class' key (not allowed in hacs.json)
- Keep valid keys: name, country, homeassistant

Add documentation for required repository topics setup that must be added manually via GitHub web interface.

Fixes HACS validation to meet repository inclusion requirements.