### PR TITLE
Fix sensor state class configuration for ENERGY device class

### DIFF
--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -248,7 +248,7 @@ class RedEnergyDailyAverageSensor(RedEnergyBaseSensor):
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_native_unit_of_measurement = "MJ"
             
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = None
 
     @property
     def native_value(self) -> Optional[float]:
@@ -300,7 +300,7 @@ class RedEnergyMonthlyAverageSensor(RedEnergyBaseSensor):
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_native_unit_of_measurement = "MJ"
             
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = None
 
     @property
     def native_value(self) -> Optional[float]:
@@ -341,7 +341,7 @@ class RedEnergyPeakUsageSensor(RedEnergyBaseSensor):
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_native_unit_of_measurement = "MJ"
             
-        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_state_class = None
 
     @property
     def native_value(self) -> Optional[float]:


### PR DESCRIPTION
 Fix RedEnergyDailyAverageSensor state class from MEASUREMENT to None
- Fix RedEnergyMonthlyAverageSensor state class from MEASUREMENT to None
- Fix RedEnergyPeakUsageSensor state class from MEASUREMENT to None
- Resolves Home Assistant log errors about incompatible state classes
- Maintains ENERGY device class while using appropriate state class for calculated values