### PR TITLE
data-validation: Handle null address fields from Red Energy API

### DIFF
--- a/.cursor/rules/red-energy-api-structure.mdc
+++ b/.cursor/rules/red-energy-api-structure.mdc
@@ -173,11 +173,15 @@ The integration looks for property ID in this order:
 }
 ```
 
+### Nullable Fields
+
+Address fields can be `null` in the API (e.g. unit-only, PO Box, or incomplete data). Validation must use `(data.get("field") or "").strip()` so that `None` does not cause `AttributeError: 'NoneType' object has no attribute 'strip'`.
+
 ### Field Mappings
 
 | API Field | Our Internal Field | Transformation |
 |-----------|-------------------|----------------|
-| `house` + `street` | `street` | Combined: `"27 SUNNYSIDE CRES"` |
+| `house` + `street` | `street` | Combined: `"27 SUNNYSIDE CRES"` (handle null) |
 | `suburb` | `city` | Direct mapping |
 | `state` | `state` | Direct mapping |
 | `postcode` | `postcode` | Direct mapping |
@@ -451,6 +455,14 @@ elif utility == "G":
 
 **Fixed in:** 2025-10-06
 
+### Issue 6: "'NoneType' object has no attribute 'strip'" during validation
+
+**Cause:** The API returns `null` for address fields (e.g. `house`, `street`, `suburb`) when the key is present but the value is missing. Using `data.get("house", "").strip()` returns the default only when the key is absent; when the key exists with value `None`, `.strip()` is called on `None`.
+
+**Solution:** Use `(data.get("house") or "").strip()` (and same pattern for other address fields) so both missing keys and `None` values become empty strings before `.strip()`.
+
+**Fixed in:** 2025-02-10
+
 ---
 
 ## 8. Data Transformation Examples
@@ -513,6 +525,10 @@ elif utility == "G":
 ---
 
 ## 9. Version History
+
+### v5 (2025-02-10)
+- ✅ Address validation handles `null` values from API (`house`, `street`, `suburb`, `city`, `state`, `postcode`)
+- ✅ Prevents `AttributeError: 'NoneType' object has no attribute 'strip'` during config flow validation
 
 ### v4 (2025-10-06)
 - ✅ Added support for `consumers` array (vs `services`)

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ venv.bak/
 
 # IDEs
 .claude/
-.cursor/
 .vscode/
 .idea/
 *.swp

--- a/custom_components/red_energy/data_validation.py
+++ b/custom_components/red_energy/data_validation.py
@@ -115,9 +115,9 @@ def validate_single_property(data: Dict[str, Any]) -> Dict[str, Any]:
             
             # Fall back to building from address parts
             if not property_name:
-                house = address_data.get("house", "").strip()
-                street = address_data.get("street", "").strip()
-                suburb = address_data.get("suburb", "").strip()
+                house = (address_data.get("house") or "").strip()
+                street = (address_data.get("street") or "").strip()
+                suburb = (address_data.get("suburb") or "").strip()
                 if house and street and suburb:
                     property_name = f"{house} {street}, {suburb}"
                 elif street and suburb:
@@ -148,12 +148,10 @@ def validate_address(data: Dict[str, Any]) -> Dict[str, Any]:
     if not isinstance(data, dict):
         data = {}
     
-    # Build full street address from house + street
-    house = data.get("house", "").strip()
-    street = data.get("street", "").strip()
+    house = (data.get("house") or "").strip()
+    street = (data.get("street") or "").strip()
     
     if house and street:
-        # Combine house number with street name
         full_street = f"{house} {street}"
     elif street:
         full_street = street
@@ -162,16 +160,15 @@ def validate_address(data: Dict[str, Any]) -> Dict[str, Any]:
     else:
         full_street = ""
     
-    # API uses "suburb" instead of "city"
-    city = data.get("city", "").strip()
+    city = (data.get("city") or "").strip()
     if not city:
-        city = data.get("suburb", "").strip()
+        city = (data.get("suburb") or "").strip()
     
     return {
         "street": full_street,
         "city": city,
-        "state": data.get("state", "").strip(),
-        "postcode": data.get("postcode", "").strip(),
+        "state": (data.get("state") or "").strip(),
+        "postcode": (data.get("postcode") or "").strip(),
     }
 
 

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.7.4"
+  "version": "1.7.5"
 }

--- a/tests/test_data_validation_errors.py
+++ b/tests/test_data_validation_errors.py
@@ -2,6 +2,8 @@
 import pytest
 from custom_components.red_energy.data_validation import (
     validate_usage_data,
+    validate_address,
+    validate_properties_data,
     DataValidationError
 )
 
@@ -229,3 +231,66 @@ def test_validate_usage_data_error_response_with_missing_error_fields_logging(ca
     assert "Skipping validation for error response" in caplog.text
     assert "Unknown error" in caplog.text
     assert "No details" in caplog.text
+
+
+def test_validate_address_handles_none_values():
+    """Test that address with null/None fields does not raise AttributeError."""
+    address_with_nulls = {
+        "house": None,
+        "street": None,
+        "suburb": None,
+        "city": None,
+        "state": None,
+        "postcode": None,
+    }
+    result = validate_address(address_with_nulls)
+    assert result["street"] == ""
+    assert result["city"] == ""
+    assert result["state"] == ""
+    assert result["postcode"] == ""
+
+
+def test_validate_address_handles_partial_none_values():
+    """Test address with some None and some string values."""
+    address = {
+        "house": None,
+        "street": "SUNNYSIDE CRES",
+        "suburb": "CASTLECRAG",
+        "state": "NSW",
+        "postcode": "2068",
+    }
+    result = validate_address(address)
+    assert result["street"] == "SUNNYSIDE CRES"
+    assert result["city"] == "CASTLECRAG"
+    assert result["state"] == "NSW"
+    assert result["postcode"] == "2068"
+
+
+def test_validate_properties_data_handles_address_with_none_house():
+    """Test property validation when API returns house: null (e.g. unit-only address)."""
+    raw_properties = [
+        {
+            "accountNumber": 8490263,
+            "address": {
+                "house": None,
+                "street": "SUNNYSIDE CRES",
+                "suburb": "CASTLECRAG",
+                "state": "NSW",
+                "postcode": "2068",
+            },
+            "consumers": [
+                {
+                    "consumerNumber": 4235478511,
+                    "utility": "E",
+                    "status": "ON",
+                }
+            ],
+        }
+    ]
+    result = validate_properties_data(raw_properties)
+    assert len(result) == 1
+    assert result[0]["id"] == "8490263"
+    assert result[0]["address"]["street"] == "SUNNYSIDE CRES"
+    assert result[0]["address"]["city"] == "CASTLECRAG"
+    assert result[0]["address"]["state"] == "NSW"
+    assert result[0]["address"]["postcode"] == "2068"


### PR DESCRIPTION
- Use (value or "").strip() for address fields to avoid NoneType.strip() errors
- Add unit tests for null and partial-null address and property validation
- Document nullable address fields and fix in API structure rules