### PR TITLE
chore: bump version to 1.7.6

### DIFF
--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.7.5"
+  "version": "1.7.6"
 }


### PR DESCRIPTION
Bumps `manifest.json` version from 1.7.5 → 1.7.6 following the bug fix for Anytime (ALLDAY) tariff breakdown mismatch warnings (closes #29, merged in #30).

https://claude.ai/code/session_01UTEirE4KH6XeMExpNCLrep