### PR TITLE
fix: serialize auth to fix Okta redirect race

### DIFF
--- a/custom_components/red_energy/api.py
+++ b/custom_components/red_energy/api.py
@@ -1,6 +1,7 @@
 """Red Energy API client for Home Assistant integration."""
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import secrets
@@ -42,9 +43,19 @@ class RedEnergyAPI:
         self._refresh_token: Optional[str] = None
         self._token_expires: Optional[datetime] = None
         self._logged_entry_mapping: bool = False
-        
+        self._auth_lock = asyncio.Lock()
+
     async def authenticate(self, username: str, password: str) -> bool:
-        """Authenticate with Red Energy using Okta session token and OAuth2 PKCE flow."""
+        """Authenticate with Red Energy using Okta session token and OAuth2 PKCE flow.
+
+        Serialized by a lock: the Okta authorization flow shares this client's
+        aiohttp session, so overlapping flows can corrupt Okta's session/cookie
+        state and cause the authorization redirect to fail.
+        """
+        async with self._auth_lock:
+            return await self._authenticate_locked(username, password)
+
+    async def _authenticate_locked(self, username: str, password: str) -> bool:
         try:
             _LOGGER.debug("Starting Red Energy authentication")
             

--- a/custom_components/red_energy/data_validation.py
+++ b/custom_components/red_energy/data_validation.py
@@ -414,9 +414,10 @@ def validate_usage_entry(data: Dict[str, Any]) -> Dict[str, Any]:
             )
     
     # Validate cost calculation
+    # Tolerance of 0.015 absorbs floating-point rounding on cent-level API values
     if all(k in validated_data for k in ["import_cost", "export_credit", "net_cost"]):
         calculated_net = validated_data["import_cost"] - validated_data["export_credit"]
-        if abs(calculated_net - validated_data["net_cost"]) > 0.01:
+        if abs(calculated_net - validated_data["net_cost"]) > 0.015:
             _LOGGER.warning(
                 "Net cost mismatch for %s: calculated=%.2f, stored=%.2f",
                 date_str, calculated_net, validated_data["net_cost"]

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.7.7"
+  "version": "1.7.8"
 }

--- a/tests/test_api_auth_concurrency.py
+++ b/tests/test_api_auth_concurrency.py
@@ -1,0 +1,59 @@
+"""Tests for concurrent authenticate() calls not racing each other."""
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+from custom_components.red_energy.api import RedEnergyAPI
+
+
+@pytest.fixture
+def api_client():
+    """Create API client for testing."""
+    session = AsyncMock()
+    return RedEnergyAPI(session)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_authenticate_calls_do_not_overlap(api_client, monkeypatch):
+    """Two concurrent authenticate() calls must not execute the Okta flow in parallel.
+
+    A shared aiohttp session means overlapping auth flows can corrupt Okta's
+    session/cookie state and cause the authorization redirect to fail. The
+    fix serializes authenticate() so a second caller waits for the first
+    in-flight attempt instead of racing it.
+    """
+    concurrent_calls = 0
+    max_concurrent = 0
+
+    async def fake_get_session_token(username, password):
+        nonlocal concurrent_calls, max_concurrent
+        concurrent_calls += 1
+        max_concurrent = max(max_concurrent, concurrent_calls)
+        await asyncio.sleep(0.01)
+        concurrent_calls -= 1
+        return "session_token", "2099-01-01T00:00:00.000Z"
+
+    async def fake_get_discovery_data():
+        return {
+            "authorization_endpoint": "https://example.okta.com/authorize",
+            "token_endpoint": "https://example.okta.com/token",
+        }
+
+    async def fake_get_authorization_code(auth_endpoint, session_token, client_id, code_challenge):
+        return "auth_code"
+
+    async def fake_exchange_code_for_tokens(token_endpoint, auth_code, client_id, code_verifier):
+        api_client._access_token = "access_token"
+        api_client._refresh_token = "refresh_token"
+
+    monkeypatch.setattr(api_client, "_get_session_token", fake_get_session_token)
+    monkeypatch.setattr(api_client, "_get_discovery_data", fake_get_discovery_data)
+    monkeypatch.setattr(api_client, "_get_authorization_code", fake_get_authorization_code)
+    monkeypatch.setattr(api_client, "_exchange_code_for_tokens", fake_exchange_code_for_tokens)
+
+    results = await asyncio.gather(
+        api_client.authenticate("user", "pass"),
+        api_client.authenticate("user", "pass"),
+    )
+
+    assert results == [True, True]
+    assert max_concurrent == 1


### PR DESCRIPTION
## Summary
- Bump version to 1.7.8
- `authenticate()` had no concurrency guard — overlapping update triggers (e.g. startup first-refresh racing a manual `red_energy.refresh_data` call or refresh button press) could run two Okta authorization flows at once on the same shared `aiohttp` session, corrupting Okta's session/cookie state. This caused `/authorize` to return an HTML page instead of a redirect, surfacing as `RedEnergyAuthError: No redirect location found in authorization response`. Fixed by wrapping `authenticate()` in an `asyncio.Lock`.
- Widen `net_cost` mismatch tolerance from 0.01 to 0.015 to absorb cent-level floating-point rounding on API values that was tripping false-positive mismatch warnings.