### PR TITLE
feat: select accounts from the options flow

### DIFF
--- a/custom_components/red_energy/config_flow.py
+++ b/custom_components/red_energy/config_flow.py
@@ -274,14 +274,24 @@ class RedEnergyOptionsFlowHandler(config_entries.OptionsFlow):
             }
 
         if user_input is not None:
+            current_services = entry.data.get("services", [SERVICE_TYPE_ELECTRICITY])
             new_selected_accounts = user_input.get(
                 "accounts", current_selected_accounts
             )
+            new_services = user_input.get("services", current_services)
 
-            if set(new_selected_accounts) != set(current_selected_accounts):
+            # entry.data (not entry.options) is what the coordinator reads, so
+            # account/service changes must be written there to take effect.
+            if set(new_selected_accounts) != set(current_selected_accounts) or set(
+                new_services
+            ) != set(current_services):
                 self.hass.config_entries.async_update_entry(
                     entry,
-                    data={**entry.data, DATA_SELECTED_ACCOUNTS: new_selected_accounts},
+                    data={
+                        **entry.data,
+                        DATA_SELECTED_ACCOUNTS: new_selected_accounts,
+                        "services": new_services,
+                    },
                 )
                 await self.hass.config_entries.async_reload(entry.entry_id)
 

--- a/custom_components/red_energy/config_flow.py
+++ b/custom_components/red_energy/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 
 from .api import RedEnergyAPI, RedEnergyAPIError, RedEnergyAuthError
-from .data_validation import validate_config_data, DataValidationError
+from .data_validation import validate_config_data, validate_properties_data, DataValidationError
 from .const import (
     CLIENT_ID,
     CONF_ENABLE_ADVANCED_SENSORS,
@@ -249,61 +249,105 @@ class RedEnergyOptionsFlowHandler(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
+        entry = self.config_entry
+        current_selected_accounts = entry.data.get(DATA_SELECTED_ACCOUNTS, [])
+
+        # Fetch the current list of properties/accounts from the API so newly
+        # added accounts (e.g. a gas service added after initial setup) can
+        # be selected, not just the ones that existed at setup time.
+        account_options: dict[str, str] = {}
+        try:
+            session = async_get_clientsession(self.hass)
+            api = RedEnergyAPI(session)
+            await api.test_credentials(
+                entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]
+            )
+            raw_properties = await api.get_properties()
+            for account in validate_properties_data(raw_properties):
+                account_options[account["id"]] = account.get("name", account["id"])
+        except Exception as err:
+            _LOGGER.warning("Could not refresh account list for options flow: %s", err)
+            # Fall back to the accounts already known to the config entry so the
+            # form can still be shown even if the API is temporarily unreachable.
+            account_options = {
+                account_id: account_id for account_id in current_selected_accounts
+            }
+
         if user_input is not None:
+            new_selected_accounts = user_input.get(
+                "accounts", current_selected_accounts
+            )
+
+            if set(new_selected_accounts) != set(current_selected_accounts):
+                self.hass.config_entries.async_update_entry(
+                    entry,
+                    data={**entry.data, DATA_SELECTED_ACCOUNTS: new_selected_accounts},
+                )
+                await self.hass.config_entries.async_reload(entry.entry_id)
+
             # Update coordinator polling interval if changed
-            entry_data = self.hass.data[DOMAIN][self.config_entry.entry_id]
+            entry_data = self.hass.data[DOMAIN][entry.entry_id]
             coordinator = entry_data["coordinator"]
-            
+
             new_interval_key = user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
             # Convert string key to seconds value
             if isinstance(new_interval_key, str):
                 new_interval_seconds = SCAN_INTERVAL_OPTIONS.get(new_interval_key, DEFAULT_SCAN_INTERVAL)
             else:
                 new_interval_seconds = new_interval_key
-            
+
             if new_interval_seconds != coordinator.update_interval.total_seconds():
                 coordinator.update_interval = timedelta(seconds=new_interval_seconds)
                 _LOGGER.info("Updated polling interval to %d seconds", new_interval_seconds)
-            
+
             return self.async_create_entry(title="", data=user_input)
 
         # Get current configuration
-        current_services = self.config_entry.data.get("services", [SERVICE_TYPE_ELECTRICITY])
-        current_options = self.config_entry.options
+        current_services = entry.data.get("services", [SERVICE_TYPE_ELECTRICITY])
+        current_options = entry.options
         current_scan_interval = current_options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         current_advanced_sensors = current_options.get(CONF_ENABLE_ADVANCED_SENSORS, False)
-        
+
         service_options = {
             SERVICE_TYPE_ELECTRICITY: "Electricity",
             SERVICE_TYPE_GAS: "Gas",
         }
-        
+
         # Create interval display options
         interval_options = {}
         for key, seconds in SCAN_INTERVAL_OPTIONS.items():
             if seconds == 900:
                 interval_options[key] = "15 minutes"
             elif seconds == 1800:
-                interval_options[key] = "30 minutes (default)"  
+                interval_options[key] = "30 minutes (default)"
             elif seconds == 3600:
                 interval_options[key] = "1 hour"
             elif seconds == 7200:
                 interval_options[key] = "2 hours"
             elif seconds == 14400:
                 interval_options[key] = "4 hours"
-        
+
+        # Default selection includes accounts already selected, even if the
+        # API call above failed to confirm they still exist.
+        accounts_default = [
+            account_id
+            for account_id in current_selected_accounts
+            if account_id in account_options
+        ] or current_selected_accounts
+
         schema = vol.Schema({
+            vol.Required("accounts", default=accounts_default): cv.multi_select(account_options),
             vol.Required("services", default=current_services): cv.multi_select(service_options),
             vol.Required(CONF_SCAN_INTERVAL, default=current_scan_interval): vol.In(interval_options),
             vol.Required(CONF_ENABLE_ADVANCED_SENSORS, default=current_advanced_sensors): bool,
         })
-        
+
         # Convert current_scan_interval to minutes for display
         if isinstance(current_scan_interval, str):
             current_scan_interval_seconds = SCAN_INTERVAL_OPTIONS.get(current_scan_interval, DEFAULT_SCAN_INTERVAL)
         else:
             current_scan_interval_seconds = current_scan_interval
-        
+
         current_interval_minutes = current_scan_interval_seconds // 60
 
         return self.async_show_form(

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.7.8"
+  "version": "1.8.0"
 }

--- a/custom_components/red_energy/translations/en.json
+++ b/custom_components/red_energy/translations/en.json
@@ -31,8 +31,9 @@
     "step": {
       "init": {
         "title": "Red Energy Options",
-        "description": "Configure which services to monitor.",
+        "description": "Configure which accounts and services to monitor.",
         "data": {
+          "accounts": "Accounts to Monitor",
           "services": "Services to Monitor",
           "scan_interval": "Scan Interval",
           "enable_advanced_sensors": "Enable Advanced Sensors"

--- a/tests/test_config_flow_options_accounts.py
+++ b/tests/test_config_flow_options_accounts.py
@@ -1,0 +1,120 @@
+"""Test the Red Energy options flow account selection."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.red_energy.const import DATA_SELECTED_ACCOUNTS, DOMAIN
+from custom_components.red_energy.config_flow import RedEnergyOptionsFlowHandler
+
+MOCK_ENTRY_DATA = {
+    "username": "test@example.com",
+    "password": "testpass",
+    DATA_SELECTED_ACCOUNTS: ["8490263"],
+    "services": ["electricity"],
+}
+
+def _raw_property(account_number, utility, consumer_number):
+    return {
+        "accountNumber": account_number,
+        "displayAddresses": {"shortForm": "27 Sunnyside Crescent, Castlecrag"},
+        "address": {
+            "suburb": "Castlecrag",
+            "state": "NSW",
+            "postcode": "2068",
+            "displayAddresses": {"shortForm": "27 Sunnyside Crescent, Castlecrag"},
+        },
+        "consumers": [
+            {
+                "consumerNumber": consumer_number,
+                "utility": utility,
+                "status": "ON",
+            }
+        ],
+    }
+
+
+MOCK_PROPERTIES_RESPONSE = [
+    _raw_property(8490263, "E", 4235478511),
+    _raw_property(7471493, "G", 4236257811),
+]
+
+
+def _make_config_entry():
+    entry = MagicMock()
+    entry.data = dict(MOCK_ENTRY_DATA)
+    entry.options = {}
+    entry.entry_id = "test_entry_id"
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_options_init_form_lists_newly_discovered_account():
+    """The options form must offer the newly-appeared account, not just the originally selected one."""
+    entry = _make_config_entry()
+    hass = MagicMock()
+    hass.data = {DOMAIN: {entry.entry_id: {"coordinator": MagicMock(update_interval=MagicMock(total_seconds=lambda: 1800))}}}
+
+    flow = RedEnergyOptionsFlowHandler()
+    flow.hass = hass
+    flow._config_entry = entry
+
+    with patch(
+        "custom_components.red_energy.config_flow.async_get_clientsession"
+    ), patch(
+        "custom_components.red_energy.config_flow.RedEnergyAPI"
+    ) as mock_api_cls:
+        mock_api = mock_api_cls.return_value
+        mock_api.test_credentials = AsyncMock(return_value=True)
+        mock_api.get_properties = AsyncMock(return_value=MOCK_PROPERTIES_RESPONSE)
+
+        result = await flow.async_step_init()
+
+    assert result["type"] == "form"
+    # The selector's option values should include the newly-discovered gas account
+    schema_dict = result["data_schema"]({
+        "accounts": ["8490263", "7471493"],
+        "services": ["electricity"],
+        "scan_interval": "30min",
+        "enable_advanced_sensors": False,
+    })
+    assert schema_dict["accounts"] == ["8490263", "7471493"]
+
+
+@pytest.mark.asyncio
+async def test_options_submit_adds_new_account_and_reloads():
+    """Selecting the new account in options must persist it and trigger a reload."""
+    entry = _make_config_entry()
+    hass = MagicMock()
+    hass.data = {DOMAIN: {entry.entry_id: {"coordinator": MagicMock(update_interval=MagicMock(total_seconds=lambda: 1800))}}}
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config_entries.async_reload = AsyncMock()
+
+    flow = RedEnergyOptionsFlowHandler()
+    flow.hass = hass
+    flow._config_entry = entry
+
+    user_input = {
+        "accounts": ["8490263", "7471493"],
+        "services": ["electricity", "gas"],
+        "scan_interval": "30min",
+        "enable_advanced_sensors": False,
+    }
+
+    with patch(
+        "custom_components.red_energy.config_flow.async_get_clientsession"
+    ), patch(
+        "custom_components.red_energy.config_flow.RedEnergyAPI"
+    ) as mock_api_cls:
+        mock_api = mock_api_cls.return_value
+        mock_api.test_credentials = AsyncMock(return_value=True)
+        mock_api.get_properties = AsyncMock(return_value=MOCK_PROPERTIES_RESPONSE)
+
+        result = await flow.async_step_init(user_input)
+
+    assert result["type"] == "create_entry"
+    hass.config_entries.async_update_entry.assert_called_once()
+    _, kwargs = hass.config_entries.async_update_entry.call_args
+    assert kwargs["data"][DATA_SELECTED_ACCOUNTS] == ["8490263", "7471493"]
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)

--- a/tests/test_config_flow_options_accounts.py
+++ b/tests/test_config_flow_options_accounts.py
@@ -118,3 +118,46 @@ async def test_options_submit_adds_new_account_and_reloads():
     _, kwargs = hass.config_entries.async_update_entry.call_args
     assert kwargs["data"][DATA_SELECTED_ACCOUNTS] == ["8490263", "7471493"]
     hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_options_submit_enabling_gas_service_persists_and_reloads():
+    """Turning on the Gas service checkbox must actually take effect.
+
+    entry.data["services"] is what the coordinator reads (entry.options is
+    never consulted), so toggling "gas" on in the options form must update
+    entry.data and reload — otherwise the checkbox is a no-op.
+    """
+    entry = _make_config_entry()
+    hass = MagicMock()
+    hass.data = {DOMAIN: {entry.entry_id: {"coordinator": MagicMock(update_interval=MagicMock(total_seconds=lambda: 1800))}}}
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config_entries.async_reload = AsyncMock()
+
+    flow = RedEnergyOptionsFlowHandler()
+    flow.hass = hass
+    flow._config_entry = entry
+
+    user_input = {
+        "accounts": ["8490263"],
+        "services": ["electricity", "gas"],
+        "scan_interval": "30min",
+        "enable_advanced_sensors": False,
+    }
+
+    with patch(
+        "custom_components.red_energy.config_flow.async_get_clientsession"
+    ), patch(
+        "custom_components.red_energy.config_flow.RedEnergyAPI"
+    ) as mock_api_cls:
+        mock_api = mock_api_cls.return_value
+        mock_api.test_credentials = AsyncMock(return_value=True)
+        mock_api.get_properties = AsyncMock(return_value=MOCK_PROPERTIES_RESPONSE)
+
+        await flow.async_step_init(user_input)
+
+    hass.config_entries.async_update_entry.assert_called_once()
+    _, kwargs = hass.config_entries.async_update_entry.call_args
+    assert kwargs["data"]["services"] == ["electricity", "gas"]
+    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)


### PR DESCRIPTION
## Summary
- Bump version to 1.8.0
- `selected_accounts` was captured once at initial setup and auto-selected whatever properties existed at that time; there was no way to add an account created afterwards (e.g. a gas service billed under a separate account number from electricity at the same address). The coordinator correctly skipped the unselected account every poll (`Property ... not in selected_accounts [...] - SKIPPING`), but there was no UI path to fix it short of removing and re-adding the whole integration.
- The options flow now re-fetches the current property list from the API on open and shows an "Accounts to Monitor" multi-select, defaulting to the currently selected accounts. Changing the selection updates the config entry and reloads it.
- Found and fixed a second, coupled bug while testing the above: the options flow's existing "Services to Monitor" checkbox wrote to `entry.options`, but the coordinator only ever reads `entry.services` from `entry.data` (fixed at initial setup) — so toggling Gas on in options silently did nothing. Now persisted to `entry.data` alongside the account selection, with a reload.
- Added `translations/en.json` entry for the new field.