### PR TITLE
fix: distinguish devices across split accounts

### DIFF
--- a/custom_components/red_energy/device_manager.py
+++ b/custom_components/red_energy/device_manager.py
@@ -63,9 +63,8 @@ class RedEnergyDeviceManager:
         account_services = [
             s.get("type") for s in property_info.get("services", []) if s.get("type")
         ] or services
-        property_name = property_info.get("name", f"Property {account_id}")
         service_label = "/".join(s.title() for s in account_services)
-        device_name = f"{property_name} ({service_label}) - {account_id}" if service_label else f"{property_name} - {account_id}"
+        device_name = f"{account_id} - {service_label}" if service_label else str(account_id)
         address = property_info.get("address", {})
 
         # Create comprehensive device identifiers

--- a/custom_components/red_energy/device_manager.py
+++ b/custom_components/red_energy/device_manager.py
@@ -50,24 +50,33 @@ class RedEnergyDeviceManager:
         return devices
 
     async def _create_property_device(
-        self, 
-        account_id: str, 
+        self,
+        account_id: str,
         property_info: Dict[str, Any],
         services: List[str]
     ) -> Optional[DeviceEntry]:
         """Create or update a device for a property."""
+        # Red Energy can split a single address across multiple accounts
+        # (e.g. electricity and gas billed separately), so the account's own
+        # service type(s) - not the global services toggle - must drive the
+        # device name/model to keep devices distinguishable per account.
+        account_services = [
+            s.get("type") for s in property_info.get("services", []) if s.get("type")
+        ] or services
         property_name = property_info.get("name", f"Property {account_id}")
+        service_label = "/".join(s.title() for s in account_services)
+        device_name = f"{property_name} ({service_label}) - {account_id}" if service_label else f"{property_name} - {account_id}"
         address = property_info.get("address", {})
-        
+
         # Create comprehensive device identifiers
         identifiers = {(DOMAIN, account_id)}
-        
+
         # Enhanced device information
         device_info = {
             "identifiers": identifiers,
-            "name": property_name,
+            "name": device_name,
             "manufacturer": MANUFACTURER,
-            "model": self._get_device_model(services),
+            "model": self._get_device_model(account_services),
             "sw_version": self._get_software_version(),
             "configuration_url": "https://www.redenergy.com.au/login",
         }
@@ -92,7 +101,7 @@ class RedEnergyDeviceManager:
         )
         
         # Update device attributes if needed
-        await self._update_device_attributes(device, property_info, services)
+        await self._update_device_attributes(device, property_info, account_services)
         
         return device
 

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.8.1"
+  "version": "1.8.2"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -68,9 +68,19 @@ async def async_setup_entry(
     
     entities = []
     
-    # Create sensors for each selected account and service
+    # Create sensors for each selected account and service. An account only
+    # ever bills one service (Red Energy splits electricity and gas onto
+    # separate accounts), so skip any service the account doesn't actually
+    # have rather than creating permanently-unavailable entities for it.
     for account_id in selected_accounts:
         for service_type in services:
+            if coordinator.get_service_metadata(account_id, service_type) is None:
+                _LOGGER.debug(
+                    "Account %s has no %s service - skipping entity creation",
+                    account_id, service_type
+                )
+                continue
+
             # Core sensors (always created)
             entities.extend([
                 RedEnergyCostSensor(coordinator, config_entry, account_id, service_type),
@@ -124,10 +134,8 @@ async def async_setup_entry(
                 ])
     
     _LOGGER.debug(
-        "Created %d sensors (%d core, %d advanced) for Red Energy integration", 
+        "Created %d sensors for Red Energy integration",
         len(entities),
-        len(selected_accounts) * len(services) * 22,  # Core sensors per account/service
-        len(entities) - (len(selected_accounts) * len(services) * 22)  # Advanced sensors
     )
     
     _LOGGER.debug("About to register %d entities with Home Assistant", len(entities))
@@ -166,19 +174,10 @@ class RedEnergyBaseSensor(CoordinatorEntity, SensorEntity):
         self._property_id = property_id
         self._service_type = service_type
         self._sensor_type = sensor_type
-        
-        # Get property info for naming
-        property_data = None
-        if coordinator.data and "usage_data" in coordinator.data:
-            property_data = coordinator.data["usage_data"].get(property_id, {}).get("property")
-        
-        property_name = "Unknown Property"
-        if property_data:
-            property_name = property_data.get("name", f"Property {property_id}")
-            
+
         service_display = service_type.title()
-        
-        self._attr_name = f"{property_name} {service_display} {sensor_type.replace('_', ' ').title()}"
+
+        self._attr_name = f"{property_id} {service_display} {sensor_type.replace('_', ' ').title()}"
         self._attr_unique_id = f"{DOMAIN}_{config_entry.entry_id}_{property_id}_{service_type}_{sensor_type}"
         
         # Set device info for grouping (device_manager handles full device metadata)

--- a/tests/test_device_manager_split_accounts.py
+++ b/tests/test_device_manager_split_accounts.py
@@ -1,0 +1,77 @@
+"""Test device naming when electricity and gas live on separate accounts."""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.red_energy.const import (
+    DOMAIN,
+    SERVICE_TYPE_ELECTRICITY,
+    SERVICE_TYPE_GAS,
+)
+from custom_components.red_energy.device_manager import RedEnergyDeviceManager
+
+ADDRESS = {"street_address": "27 Sunnyside Crescent", "suburb": "Castlecrag"}
+
+
+def _property_info(name, service_type):
+    return {
+        "name": name,
+        "address": ADDRESS,
+        "services": [{"type": service_type}],
+    }
+
+
+def _fake_device(**kwargs):
+    device = MagicMock()
+    device.name = kwargs.get("name")
+    return device
+
+
+def _make_device_manager():
+    mock_hass = MagicMock()
+    mock_config_entry = MagicMock()
+    mock_config_entry.entry_id = "entry1"
+
+    manager = RedEnergyDeviceManager(mock_hass, mock_config_entry)
+    manager._device_registry = MagicMock()
+    manager._device_registry.async_get_or_create.side_effect = _fake_device
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_split_accounts_at_same_address_get_distinct_device_names():
+    """Electricity and gas on separate accounts at the same address must not collide."""
+    manager = _make_device_manager()
+
+    electricity_device = await manager._create_property_device(
+        "8490263",
+        _property_info("27 Sunnyside Crescent, Castlecrag", SERVICE_TYPE_ELECTRICITY),
+        [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
+    )
+    gas_device = await manager._create_property_device(
+        "7471493",
+        _property_info("27 Sunnyside Crescent, Castlecrag", SERVICE_TYPE_GAS),
+        [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
+    )
+
+    assert electricity_device.name != gas_device.name
+    assert "8490263" in electricity_device.name
+    assert "7471493" in gas_device.name
+    assert "Electricity" in electricity_device.name
+    assert "Gas" in gas_device.name
+
+
+@pytest.mark.asyncio
+async def test_device_model_reflects_accounts_own_service_not_global_toggle():
+    """A gas-only account must get 'Gas Monitor', even if the global toggle enables both."""
+    manager = _make_device_manager()
+
+    await manager._create_property_device(
+        "7471493",
+        _property_info("27 Sunnyside Crescent, Castlecrag", SERVICE_TYPE_GAS),
+        [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
+    )
+
+    _, kwargs = manager._device_registry.async_get_or_create.call_args
+    assert kwargs["model"] == "Gas Monitor"

--- a/tests/test_device_manager_split_accounts.py
+++ b/tests/test_device_manager_split_accounts.py
@@ -56,10 +56,8 @@ async def test_split_accounts_at_same_address_get_distinct_device_names():
     )
 
     assert electricity_device.name != gas_device.name
-    assert "8490263" in electricity_device.name
-    assert "7471493" in gas_device.name
-    assert "Electricity" in electricity_device.name
-    assert "Gas" in gas_device.name
+    assert electricity_device.name == "8490263 - Electricity"
+    assert gas_device.name == "7471493 - Gas"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -142,6 +142,26 @@ class TestSensorDisplayNames:
         assert "Daily Import Usage" in sensor._attr_name
         assert "_" not in sensor._attr_name.split(" ")[-3:]  # Check last 3 words don't have underscores
 
+    def test_base_sensor_name_uses_property_id_not_property_display_name(self):
+        """Entity names use the account/property ID, not the address-derived property name.
+
+        Split accounts (e.g. electricity and gas billed separately) can share
+        the same address, so the address alone doesn't distinguish entities.
+        """
+        coordinator = create_mock_coordinator()
+        config_entry = create_mock_config_entry()
+
+        sensor = RedEnergyBaseSensor(
+            coordinator,
+            config_entry,
+            "prop-001",
+            SERVICE_TYPE_ELECTRICITY,
+            "daily_import_usage"
+        )
+
+        assert sensor._attr_name.startswith("prop-001")
+        assert "Test Property" not in sensor._attr_name
+
     def test_total_cost_sensor_display_name(self):
         """Test total_cost sensor display name."""
         coordinator = create_mock_coordinator()

--- a/tests/test_sensor_setup_split_accounts.py
+++ b/tests/test_sensor_setup_split_accounts.py
@@ -1,0 +1,75 @@
+"""Test sensor platform setup does not cross-create entities for split accounts."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.red_energy.const import DOMAIN, SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS
+from custom_components.red_energy.sensor import async_setup_entry
+
+
+def _coordinator_for_split_accounts():
+    coordinator = MagicMock()
+    coordinator.data = {
+        "usage_data": {
+            "8490263": {
+                "property": {
+                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "services": [{"type": SERVICE_TYPE_ELECTRICITY, "consumer_number": "elec-1"}],
+                },
+            },
+            "7471493": {
+                "property": {
+                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "services": [{"type": SERVICE_TYPE_GAS, "consumer_number": "gas-1"}],
+                },
+            },
+        }
+    }
+    coordinator.last_update_success = True
+
+    def get_service_metadata(property_id, service_type):
+        property_data = coordinator.data["usage_data"].get(str(property_id))
+        if not property_data:
+            return None
+        services = property_data["property"].get("services", [])
+        return next((s for s in services if s.get("type") == service_type), None)
+
+    coordinator.get_service_metadata = MagicMock(side_effect=get_service_metadata)
+    coordinator.get_service_usage = MagicMock(return_value=None)
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_no_electricity_entities_created_for_gas_only_account():
+    """A gas-only account must not get electricity sensors, and vice versa."""
+    coordinator = _coordinator_for_split_accounts()
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["8490263", "7471493"],
+                "services": [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    for entity in added_entities:
+        if entity._property_id == "8490263":
+            assert entity._service_type == SERVICE_TYPE_ELECTRICITY
+        elif entity._property_id == "7471493":
+            assert entity._service_type == SERVICE_TYPE_GAS
+
+    assert any(e._property_id == "8490263" for e in added_entities)
+    assert any(e._property_id == "7471493" for e in added_entities)


### PR DESCRIPTION
## Summary
- Bump version to 1.8.2
- Red Energy can bill electricity and gas on separate accounts at the same physical address. Devices were already registered per `account_id` (distinct registry entries), but the device name and entity names were both derived from the property address, which is identical across split accounts - and the model was computed from the global services toggle, so a gas-only account could show up as "Dual Service Monitor".
- Device names now use `{account_id} - {Service}`, e.g. `8490263 - Electricity` / `7471493 - Gas`.
- Entity names now use the account_id instead of the address, e.g. `8490263 Electricity Daily Import Usage`.
- The sensor setup loop applied the global services toggle to every selected account regardless of what that account actually bills, creating a full set of permanently-unavailable entities for the wrong service (e.g. electricity sensors on a gas-only account). It now skips any service an account doesn't actually have.

Note: existing installs will see device and entity names change on upgrade as a result of this fix.