### PR TITLE
fix: options-flow account labels use ID + service

### DIFF
--- a/custom_components/red_energy/config_flow.py
+++ b/custom_components/red_energy/config_flow.py
@@ -261,7 +261,13 @@ class RedEnergyOptionsFlowHandler(config_entries.OptionsFlow):
             coordinator = self.hass.data[DOMAIN][entry.entry_id]["coordinator"]
             raw_properties = await coordinator.api.get_properties()
             for account in validate_properties_data(raw_properties):
-                account_options[account["id"]] = account.get("name", account["id"])
+                account_id = account["id"]
+                service_label = "/".join(
+                    s.get("type", "").title() for s in account.get("services", []) if s.get("type")
+                )
+                account_options[account_id] = (
+                    f"{account_id} - {service_label}" if service_label else account_id
+                )
         except Exception as err:
             _LOGGER.warning("Could not refresh account list for options flow: %s", err)
             # Fall back to the accounts already known to the config entry so the

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.8.2"
+  "version": "1.8.3"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -144,13 +144,27 @@ async def async_setup_entry(
     try:
         async_add_entities(entities)
         _LOGGER.info("Successfully registered %d entities with Home Assistant", len(entities))
-        
+
         # Check if entities are actually in the entity registry
         entity_registry = er.async_get(hass)
         red_energy_entities = [entity for entity in entity_registry.entities.values() if entity.platform == DOMAIN]
-        _LOGGER.debug("Found %d Red Energy entities in entity registry: %s", 
-                     len(red_energy_entities), 
+        _LOGGER.debug("Found %d Red Energy entities in entity registry: %s",
+                     len(red_energy_entities),
                      [entity.entity_id for entity in red_energy_entities[:10]])  # Show first 10
+
+        # Remove stale entities left over from a previous account/service
+        # selection (e.g. a service later removed from an account, or a
+        # deselected account). These stay "Unavailable" forever otherwise -
+        # HA doesn't auto-purge merely-unavailable entities, and the device
+        # itself is untouched so device-based orphan cleanup won't catch them.
+        current_unique_ids = {entity.unique_id for entity in entities}
+        for entity in er.async_entries_for_config_entry(entity_registry, config_entry.entry_id):
+            if entity.unique_id not in current_unique_ids:
+                _LOGGER.info(
+                    "Removing stale entity no longer produced by current configuration: %s",
+                    entity.entity_id,
+                )
+                entity_registry.async_remove(entity.entity_id)
         
     except Exception as err:
         _LOGGER.error("Failed to register entities with Home Assistant: %s", err, exc_info=True)

--- a/tests/test_config_flow_options_accounts.py
+++ b/tests/test_config_flow_options_accounts.py
@@ -80,6 +80,34 @@ async def test_options_init_form_lists_newly_discovered_account():
 
 
 @pytest.mark.asyncio
+async def test_options_account_labels_use_account_id_not_shared_address():
+    """Checkbox labels must disambiguate accounts sharing the same address.
+
+    Both mock properties share the display address "27 Sunnyside Crescent,
+    Castlecrag" (electricity and gas billed on separate accounts) - the
+    label shown to the user must not be that address for both, or the
+    options screen is unusable (matches the reported UI screenshot).
+    """
+    entry = _make_config_entry()
+    hass = _make_hass(entry)
+
+    flow = RedEnergyOptionsFlowHandler()
+    flow.hass = hass
+    flow._config_entry = entry
+
+    result = await flow.async_step_init()
+
+    accounts_validator = next(
+        v for k, v in result["data_schema"].schema.items() if str(k) == "accounts"
+    )
+    labels = accounts_validator.options
+
+    assert labels["8490263"] == "8490263 - Electricity"
+    assert labels["7471493"] == "7471493 - Gas"
+    assert "27 Sunnyside Crescent, Castlecrag" not in labels.values()
+
+
+@pytest.mark.asyncio
 async def test_options_submit_adds_new_account_and_reloads():
     """Selecting the new account in options must persist it and trigger a reload."""
     entry = _make_config_entry()

--- a/tests/test_sensor_stale_entity_cleanup.py
+++ b/tests/test_sensor_stale_entity_cleanup.py
@@ -1,0 +1,130 @@
+"""Test that sensor setup removes entities no longer produced by config."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.red_energy.const import DOMAIN, SERVICE_TYPE_ELECTRICITY
+from custom_components.red_energy.sensor import async_setup_entry
+
+
+def _coordinator_for_single_account():
+    coordinator = MagicMock()
+    coordinator.data = {
+        "usage_data": {
+            "8490263": {
+                "property": {
+                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "services": [{"type": SERVICE_TYPE_ELECTRICITY, "consumer_number": "elec-1"}],
+                },
+            },
+        }
+    }
+    coordinator.last_update_success = True
+
+    def get_service_metadata(property_id, service_type):
+        property_data = coordinator.data["usage_data"].get(str(property_id))
+        if not property_data:
+            return None
+        services = property_data["property"].get("services", [])
+        return next((s for s in services if s.get("type") == service_type), None)
+
+    coordinator.get_service_metadata = MagicMock(side_effect=get_service_metadata)
+    coordinator.get_service_usage = MagicMock(return_value=None)
+    return coordinator
+
+
+def _registry_entry(entity_id, unique_id):
+    entry = MagicMock()
+    entry.entity_id = entity_id
+    entry.unique_id = unique_id
+    entry.platform = DOMAIN
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_stale_entity_removed_when_no_longer_produced():
+    """An entity from a prior configuration (e.g. a deselected account) must be removed.
+
+    HA never auto-purges entities that are merely "Unavailable" - they stay
+    in the registry forever unless something explicitly removes them. Since
+    the underlying device is untouched by an account/service deselection,
+    device-based orphan cleanup won't catch these either.
+    """
+    coordinator = _coordinator_for_single_account()
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["8490263"],
+                "services": [SERVICE_TYPE_ELECTRICITY],
+            }
+        }
+    }
+
+    stale_entity = _registry_entry(
+        "sensor.stale_gas_entity",
+        "red_energy_entry1_7471493_gas_total_cost",
+    )
+
+    mock_registry = MagicMock()
+    mock_registry.entities.values.return_value = [stale_entity]
+    mock_registry.async_remove = MagicMock()
+
+    async_add_entities = MagicMock()
+
+    with patch(
+        "custom_components.red_energy.sensor.er.async_get", return_value=mock_registry
+    ), patch(
+        "custom_components.red_energy.sensor.er.async_entries_for_config_entry",
+        return_value=[stale_entity],
+    ):
+        await async_setup_entry(hass, config_entry, async_add_entities)
+
+    mock_registry.async_remove.assert_called_once_with("sensor.stale_gas_entity")
+
+
+@pytest.mark.asyncio
+async def test_current_entity_not_removed():
+    """An entity that matches the current configuration must be left alone."""
+    coordinator = _coordinator_for_single_account()
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["8490263"],
+                "services": [SERVICE_TYPE_ELECTRICITY],
+            }
+        }
+    }
+
+    async_add_entities = MagicMock()
+    created_entities = []
+    async_add_entities.side_effect = lambda entities: created_entities.extend(entities)
+
+    mock_registry = MagicMock()
+    mock_registry.entities.values.return_value = []
+    mock_registry.async_remove = MagicMock()
+
+    with patch(
+        "custom_components.red_energy.sensor.er.async_get", return_value=mock_registry
+    ), patch(
+        "custom_components.red_energy.sensor.er.async_entries_for_config_entry",
+        side_effect=lambda registry, entry_id: [
+            _registry_entry(f"sensor.{e.unique_id}", e.unique_id) for e in created_entities
+        ],
+    ):
+        await async_setup_entry(hass, config_entry, async_add_entities)
+
+    mock_registry.async_remove.assert_not_called()


### PR DESCRIPTION
## Summary
- Bump version to 1.8.3
- The accounts checklist in the options flow (added in #35) labeled each checkbox with the raw property name - the address - so split accounts sharing an address (e.g. electricity and gas billed on separate accounts) showed as two identical, indistinguishable checkboxes with no way to tell which was which. Labels now follow the same convention as device names from #37: `{account_id} - {Service}`, e.g. `8490263 - Electricity` / `7471493 - Gas`.
- Separately: entities left over from a prior configuration (a deselected account, or a service later removed from an account) never got cleaned up. Home Assistant doesn't auto-purge entities that are merely "Unavailable", and the integration's only cleanup path ran on full removal, not on reload - and even then it only caught entities whose *device* had disappeared, which doesn't happen here since the device itself is untouched by an account/service change. Sensor setup now removes any registered entity for the config entry whose `unique_id` isn't among the ones it just (re)created, so stale "Unavailable" entities clear out on the next reload instead of accumulating indefinitely.

Note: renaming an entity does not affect history - `unique_id` (what HA ties recorder history to) is unchanged by either fix, only the friendly name and stale-entity removal are affected.