### PR TITLE
fix: BASIC gas meter usage failure no longer blocks device

### DIFF
--- a/custom_components/red_energy/api.py
+++ b/custom_components/red_energy/api.py
@@ -336,13 +336,18 @@ class RedEnergyAPI:
                         error_message = 'Bad Request'
                         error_details = 'Unable to parse error response'
                     
-                    _LOGGER.error(
+                    # BASIC/manual-read gas meters don't have half-hourly interval
+                    # usage - Red Energy's API returns this as a 400 for every
+                    # request, which is expected behaviour, not a failure.
+                    is_no_interval_usage = "does not have interval usages" in error_message
+                    log_method = _LOGGER.debug if is_no_interval_usage else _LOGGER.error
+                    log_method(
                         "400 Bad Request for usage data - Consumer: %s, Date Range: %s to %s, "
                         "Error: %s, Details: %s, URL: %s",
-                        consumer_number, 
-                        from_date.strftime('%Y-%m-%d'), 
+                        consumer_number,
+                        from_date.strftime('%Y-%m-%d'),
                         to_date.strftime('%Y-%m-%d'),
-                        error_message, 
+                        error_message,
                         error_details,
                         response.url
                     )

--- a/custom_components/red_energy/config_flow.py
+++ b/custom_components/red_energy/config_flow.py
@@ -298,20 +298,31 @@ class RedEnergyOptionsFlowHandler(config_entries.OptionsFlow):
                 )
                 await self.hass.config_entries.async_reload(entry.entry_id)
 
-            # Update coordinator polling interval if changed
-            entry_data = self.hass.data[DOMAIN][entry.entry_id]
-            coordinator = entry_data["coordinator"]
+            # Update coordinator polling interval if changed. The coordinator
+            # may not be available (e.g. setup failed or is still retrying),
+            # in which case there's nothing running to update live - the
+            # entry data change above still applies on the next successful
+            # setup, so this must degrade gracefully rather than crash the
+            # options form.
+            coordinator = self.hass.data.get(DOMAIN, {}).get(entry.entry_id, {}).get("coordinator")
 
-            new_interval_key = user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-            # Convert string key to seconds value
-            if isinstance(new_interval_key, str):
-                new_interval_seconds = SCAN_INTERVAL_OPTIONS.get(new_interval_key, DEFAULT_SCAN_INTERVAL)
+            if coordinator is not None:
+                new_interval_key = user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+                # Convert string key to seconds value
+                if isinstance(new_interval_key, str):
+                    new_interval_seconds = SCAN_INTERVAL_OPTIONS.get(new_interval_key, DEFAULT_SCAN_INTERVAL)
+                else:
+                    new_interval_seconds = new_interval_key
+
+                if new_interval_seconds != coordinator.update_interval.total_seconds():
+                    coordinator.update_interval = timedelta(seconds=new_interval_seconds)
+                    _LOGGER.info("Updated polling interval to %d seconds", new_interval_seconds)
             else:
-                new_interval_seconds = new_interval_key
-
-            if new_interval_seconds != coordinator.update_interval.total_seconds():
-                coordinator.update_interval = timedelta(seconds=new_interval_seconds)
-                _LOGGER.info("Updated polling interval to %d seconds", new_interval_seconds)
+                _LOGGER.warning(
+                    "Coordinator not available for entry %s - options saved, "
+                    "polling interval will apply on next successful setup",
+                    entry.entry_id,
+                )
 
             return self.async_create_entry(title="", data=user_input)
 

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -237,15 +237,23 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
                         # Don't fail the entire update for one service error
                         continue
                 
+                # Always record the property, even if no service returned usage
+                # data (e.g. a BASIC/manual-read gas meter, which never has
+                # interval usage). Its metadata (NMI, balance, bill dates, etc.)
+                # is still valid, so the device and metadata-only sensors must
+                # still be created - only usage-dependent sensors go unavailable.
+                usage_data[property_id_str] = {
+                    "property": property_data,
+                    "services": property_usage,
+                }
                 if property_usage:
-                    usage_data[property_id_str] = {
-                        "property": property_data,
-                        "services": property_usage,
-                    }
-                    _LOGGER.info("Successfully collected usage data for property '%s' with %d services", 
+                    _LOGGER.info("Successfully collected usage data for property '%s' with %d services",
                                 property_name, len(property_usage))
                 else:
-                    _LOGGER.warning("No usage data collected for property '%s'", property_name)
+                    _LOGGER.info(
+                        "No usage data collected for property '%s' - metadata-only sensors will still be created",
+                        property_name,
+                    )
             
             _LOGGER.debug("=" * 80)
             _LOGGER.debug("DATA COLLECTION SUMMARY:")

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.8.3"
+  "version": "1.8.4"
 }

--- a/tests/test_api_400_errors.py
+++ b/tests/test_api_400_errors.py
@@ -1,4 +1,5 @@
 """Tests for API 400 error handling."""
+import logging
 import pytest
 from unittest.mock import AsyncMock, patch
 from datetime import datetime
@@ -199,3 +200,46 @@ async def test_get_usage_data_logging_on_400_error(api_client, caplog):
     assert "Error: Invalid consumer number" in caplog.text
     assert "Details: Consumer number 123 is not valid for this account" in caplog.text
     assert "URL: https://api.example.com/usage/interval" in caplog.text
+
+    # A genuine error (not the BASIC/gas no-interval-usage case) must still
+    # log at ERROR level so it's visible without enabling debug logging.
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert error_records, "Genuine 400 errors must be logged at ERROR level"
+
+
+@pytest.mark.asyncio
+async def test_get_usage_data_basic_meter_400_logs_at_debug_not_error(api_client, caplog):
+    """A BASIC/manual-read gas meter's 400 is expected behaviour, not a failure.
+
+    Red Energy returns this same 400 on every request for a non-interval
+    meter - logging it at ERROR is misleading noise for something that will
+    never resolve differently, so it must log at debug instead.
+    """
+    mock_response = AsyncMock()
+    mock_response.status = 400
+    mock_response.url = "https://api.example.com/usage/interval?consumerNumber=4236257811&fromDate=2024-01-01&toDate=2024-01-02"
+
+    error_data = {
+        "message": (
+            "customerNumber=5545090, consumerNumber=4236257811 has a BASIC "
+            "meter or is for a Gas utility so does not have interval usages"
+        ),
+        "details": "No additional details",
+    }
+    mock_response.json = AsyncMock(return_value=error_data)
+
+    async def mock_context_manager(*args, **kwargs):
+        return mock_response
+
+    api_client._session.get.return_value.__aenter__ = mock_context_manager
+    api_client._session.get.return_value.__aexit__ = AsyncMock(return_value=None)
+    api_client._access_token = "test_token"
+
+    with caplog.at_level(logging.DEBUG, logger="custom_components.red_energy.api"):
+        result = await api_client.get_usage_data("4236257811", datetime(2024, 1, 1), datetime(2024, 1, 2))
+
+    assert result["error"] is True
+
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert not error_records, f"Expected no ERROR logs, got: {[r.message for r in error_records]}"
+    assert "does not have interval usages" in caplog.text

--- a/tests/test_config_flow_options_accounts.py
+++ b/tests/test_config_flow_options_accounts.py
@@ -190,3 +190,34 @@ async def test_options_submit_enabling_gas_service_persists_and_reloads():
     _, kwargs = hass.config_entries.async_update_entry.call_args
     assert kwargs["data"]["services"] == ["electricity", "gas"]
     hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_options_submit_does_not_crash_when_coordinator_not_loaded():
+    """Submitting options must not crash if the integration failed to set up.
+
+    If setup failed (e.g. mid auth race) hass.data[DOMAIN] never gets
+    populated. The options form must still save without raising KeyError -
+    the polling-interval live-update is simply skipped in that case.
+    """
+    entry = _make_config_entry()
+    hass = MagicMock()
+    hass.data = {}  # DOMAIN key absent entirely - integration never set up
+    hass.config_entries = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config_entries.async_reload = AsyncMock()
+
+    flow = RedEnergyOptionsFlowHandler()
+    flow.hass = hass
+    flow._config_entry = entry
+
+    user_input = {
+        "accounts": ["8490263"],
+        "services": ["electricity"],
+        "scan_interval": "30min",
+        "enable_advanced_sensors": False,
+    }
+
+    result = await flow.async_step_init(user_input)
+
+    assert result["type"] == "create_entry"

--- a/tests/test_coordinator_400_errors.py
+++ b/tests/test_coordinator_400_errors.py
@@ -96,10 +96,13 @@ async def test_coordinator_handles_400_error_gracefully(coordinator, caplog):
     # Call the update method
     result = await coordinator._async_update_data()
     
-    # Verify the result contains data for the successful property only
+    # Verify the result contains data for the successful property, and the
+    # failed property is still present (metadata-only) rather than dropped -
+    # a usage failure must not remove the property/device entirely.
     assert "usage_data" in result
     assert "prop2" in result["usage_data"]  # Second property succeeded
-    assert "prop1" not in result["usage_data"]  # First property failed
+    assert "prop1" in result["usage_data"]  # First property present but empty
+    assert result["usage_data"]["prop1"]["services"] == {}
     
     # Verify warning was logged for the failed service
     assert "API returned error for electricity service (consumer 1234567890)" in caplog.text
@@ -112,7 +115,13 @@ async def test_coordinator_handles_400_error_gracefully(coordinator, caplog):
 
 @pytest.mark.asyncio
 async def test_coordinator_handles_all_services_failing(coordinator, caplog):
-    """Test coordinator behavior when all services return 400 errors."""
+    """Test coordinator behavior when all services return 400 errors.
+
+    A usage-fetch failure (e.g. a BASIC/manual-read gas meter that never has
+    interval usage) must not fail the whole update or drop the property -
+    metadata is still valid, so the device and metadata-only sensors must
+    still be created. Only a total absence of any property should raise.
+    """
     # Mock API to return 400 error for all properties
     coordinator.api.get_usage_data = AsyncMock(return_value={
         "error": True,
@@ -124,11 +133,15 @@ async def test_coordinator_handles_all_services_failing(coordinator, caplog):
         "to_date": "2024-01-02",
         "usage_data": []
     })
-    
-    # Call the update method
-    with pytest.raises(Exception):  # Should raise UpdateFailed
-        await coordinator._async_update_data()
-    
+
+    # Call the update method - must NOT raise despite every service failing
+    result = await coordinator._async_update_data()
+
+    assert "prop1" in result["usage_data"]
+    assert "prop2" in result["usage_data"]
+    assert result["usage_data"]["prop1"]["services"] == {}
+    assert result["usage_data"]["prop2"]["services"] == {}
+
     # Verify warnings were logged for all failed services
     assert "API returned error for electricity service" in caplog.text
     assert "Invalid consumer number" in caplog.text
@@ -167,11 +180,13 @@ async def test_coordinator_mixed_success_and_failure(coordinator, caplog):
     # Call the update method
     result = await coordinator._async_update_data()
     
-    # Verify we got data for the successful property
+    # Verify we got data for the successful property, and the failed
+    # property is present but with no services (metadata-only)
     assert "usage_data" in result
     assert "prop2" in result["usage_data"]
-    assert "prop1" not in result["usage_data"]
-    
+    assert "prop1" in result["usage_data"]
+    assert result["usage_data"]["prop1"]["services"] == {}
+
     # Verify the successful property has correct data
     prop2_data = result["usage_data"]["prop2"]
     assert "services" in prop2_data
@@ -204,10 +219,12 @@ async def test_coordinator_skips_inactive_services(coordinator):
     assert coordinator.api.get_usage_data.call_count == 1
     assert coordinator.api.get_usage_data.call_args[0][0] == "0987654321"  # Second property's consumer number
     
-    # Verify result contains only the active service
+    # Verify result contains the active service; the inactive-only property
+    # is still present (metadata-only), just with no services collected
     assert "usage_data" in result
     assert "prop2" in result["usage_data"]
-    assert "prop1" not in result["usage_data"]
+    assert "prop1" in result["usage_data"]
+    assert result["usage_data"]["prop1"]["services"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration_400_errors.py
+++ b/tests/test_integration_400_errors.py
@@ -193,9 +193,11 @@ async def test_integration_all_services_fail_for_one_property(coordinator_with_m
     # Call the update method
     result = await coordinator_with_multiple_properties._async_update_data()
     
-    # Verify property 1 has no usage data (all services failed)
-    assert "prop1" not in result["usage_data"]
-    
+    # Verify property 1 is still present (metadata-only) even though every
+    # service failed - a usage failure must not drop the property/device
+    assert "prop1" in result["usage_data"]
+    assert result["usage_data"]["prop1"]["services"] == {}
+
     # Verify other properties have data
     assert "prop2" in result["usage_data"]
     assert "prop3" in result["usage_data"]
@@ -310,11 +312,14 @@ async def test_integration_graceful_degradation_with_minimal_data(coordinator_wi
     # Call the update method
     result = await coordinator_with_multiple_properties._async_update_data()
     
-    # Verify we still get some data (graceful degradation)
+    # Verify we still get some data (graceful degradation), and properties
+    # whose services all failed are still present as metadata-only entries
     assert "usage_data" in result
     assert "prop3" in result["usage_data"]
-    assert "prop1" not in result["usage_data"]
-    assert "prop2" not in result["usage_data"]
+    assert "prop1" in result["usage_data"]
+    assert result["usage_data"]["prop1"]["services"] == {}
+    assert "prop2" in result["usage_data"]
+    assert result["usage_data"]["prop2"]["services"] == {}
     
     # Verify property 3 has electricity data
     prop3_data = result["usage_data"]["prop3"]


### PR DESCRIPTION
## Summary
- Bump version to 1.8.4
- A BASIC/manual-read gas meter has no half-hourly interval usage, so Red Energy's `/usage/interval` endpoint returns a 400 for it on every single request. Treating that as a real failure caused three problems:
  - `api.py` logged it at ERROR on every poll (visible in the log even without debug logging enabled), even though it's expected behaviour that will never resolve differently. Now logged at debug when the specific "does not have interval usages" message is detected; genuine 400s still log at ERROR.
  - `coordinator.py` only stored a property in `usage_data` if at least one of its services returned usage successfully - so a gas-only account with a BASIC meter never got a device or *any* entities created at all, discarding valid metadata (NMI, balance, arrears, bill dates, status, etc.) along with the legitimately-missing usage. Properties are now always recorded; only the usage-dependent sensors (import/export usage & cost, advanced sensors) go unavailable - metadata sensors show real values.
  - `config_flow.py`'s options-flow submit handler crashed with `KeyError('red_energy')` if the integration hadn't finished loading yet (e.g. mid the auth race from #34/#36) when the coordinator lookup was unguarded. Now degrades gracefully - the form still saves, the live polling-interval update is just skipped until the next successful setup.

Verified the gas device's expected sensor set against the real gas account record: all 14 metadata-backed core sensors (NMI, meter type, solar, energy plan, distributor, balance, arrears, last/next bill date, billing frequency, jurisdiction, charge class, status) map to real values in that record; the 8 usage-dependent core sensors and 13 advanced sensors correctly have no data to show.