### PR TITLE
fix: disable usage sensors by default for BASIC meters

### DIFF
--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.8.4"
+  "version": "1.8.5"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -74,15 +74,22 @@ async def async_setup_entry(
     # have rather than creating permanently-unavailable entities for it.
     for account_id in selected_accounts:
         for service_type in services:
-            if coordinator.get_service_metadata(account_id, service_type) is None:
+            service_metadata = coordinator.get_service_metadata(account_id, service_type)
+            if service_metadata is None:
                 _LOGGER.debug(
                     "Account %s has no %s service - skipping entity creation",
                     account_id, service_type
                 )
                 continue
 
+            # BASIC/manual-read meters never produce interval usage data (Red
+            # Energy's API 400s on every request for them), so usage-dependent
+            # sensors are created disabled by default rather than sitting
+            # enabled and permanently "Unknown".
+            is_basic_meter = service_metadata.get("meterType") == "BASIC"
+
             # Core sensors (always created)
-            entities.extend([
+            service_entities = [
                 RedEnergyCostSensor(coordinator, config_entry, account_id, service_type),
                 RedEnergyNmiSensor(coordinator, config_entry, account_id, service_type),
                 RedEnergyMeterTypeSensor(coordinator, config_entry, account_id, service_type),
@@ -109,11 +116,11 @@ async def async_setup_entry(
                 # Total cost/credit breakdown
                 RedEnergyTotalImportCostSensor(coordinator, config_entry, account_id, service_type),
                 RedEnergyTotalExportCreditSensor(coordinator, config_entry, account_id, service_type),
-            ])
-            
+            ]
+
             # Advanced sensors (optional)
             if advanced_sensors_enabled:
-                entities.extend([
+                service_entities.extend([
                     # Existing advanced sensors
                     RedEnergyDailyAverageSensor(coordinator, config_entry, account_id, service_type),
                     RedEnergyMonthlyAverageSensor(coordinator, config_entry, account_id, service_type),
@@ -132,6 +139,13 @@ async def async_setup_entry(
                     RedEnergyMaxDemandTimeSensor(coordinator, config_entry, account_id, service_type),
                     RedEnergyCarbonEmissionSensor(coordinator, config_entry, account_id, service_type),
                 ])
+
+            if is_basic_meter:
+                for entity in service_entities:
+                    if entity._requires_usage_data:
+                        entity._attr_entity_registry_enabled_default = False
+
+            entities.extend(service_entities)
     
     _LOGGER.debug(
         "Created %d sensors for Red Energy integration",
@@ -172,6 +186,13 @@ async def async_setup_entry(
 
 class RedEnergyBaseSensor(CoordinatorEntity, SensorEntity):
     """Base class for Red Energy sensors."""
+
+    # Whether this sensor needs interval usage data to report a value.
+    # BASIC/manual-read meters never have interval usage, so these sensors
+    # are disabled by default for such accounts (see async_setup_entry).
+    # Metadata-only sensors (NMI, balance, status, etc.) override this to
+    # False since they work regardless of meter type.
+    _requires_usage_data: bool = True
 
     def __init__(
         self,
@@ -511,6 +532,8 @@ class RedEnergyEfficiencySensor(RedEnergyBaseSensor):
 class RedEnergyNmiSensor(RedEnergyBaseSensor):
     """Red Energy NMI sensor."""
 
+    _requires_usage_data = False
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -537,6 +560,8 @@ class RedEnergyNmiSensor(RedEnergyBaseSensor):
 class RedEnergyMeterTypeSensor(RedEnergyBaseSensor):
     """Red Energy meter type sensor."""
 
+    _requires_usage_data = False
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -562,6 +587,8 @@ class RedEnergyMeterTypeSensor(RedEnergyBaseSensor):
 
 class RedEnergySolarSensor(RedEnergyBaseSensor):
     """Red Energy solar capability sensor."""
+
+    _requires_usage_data = False
 
     def __init__(
         self,
@@ -590,6 +617,8 @@ class RedEnergySolarSensor(RedEnergyBaseSensor):
 class RedEnergyProductNameSensor(RedEnergyBaseSensor):
     """Red Energy energy plan sensor."""
 
+    _requires_usage_data = False
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -616,6 +645,8 @@ class RedEnergyProductNameSensor(RedEnergyBaseSensor):
 class RedEnergyDistributorSensor(RedEnergyBaseSensor):
     """Red Energy distributor/lines company sensor."""
 
+    _requires_usage_data = False
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -641,6 +672,8 @@ class RedEnergyDistributorSensor(RedEnergyBaseSensor):
 
 class RedEnergyBalanceSensor(RedEnergyBaseSensor):
     """Red Energy account balance sensor."""
+
+    _requires_usage_data = False
 
     def __init__(
         self,
@@ -670,6 +703,8 @@ class RedEnergyBalanceSensor(RedEnergyBaseSensor):
 class RedEnergyArrearsSensor(RedEnergyBaseSensor):
     """Red Energy arrears sensor."""
 
+    _requires_usage_data = False
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -697,6 +732,8 @@ class RedEnergyArrearsSensor(RedEnergyBaseSensor):
 
 class RedEnergyLastBillDateSensor(RedEnergyBaseSensor):
     """Red Energy last bill date sensor."""
+
+    _requires_usage_data = False
 
     def __init__(
         self,
@@ -733,6 +770,8 @@ class RedEnergyLastBillDateSensor(RedEnergyBaseSensor):
 class RedEnergyNextBillDateSensor(RedEnergyBaseSensor):
     """Red Energy next bill date sensor."""
 
+    _requires_usage_data = False
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -768,6 +807,8 @@ class RedEnergyNextBillDateSensor(RedEnergyBaseSensor):
 class RedEnergyBillingFrequencySensor(RedEnergyBaseSensor):
     """Red Energy billing frequency sensor."""
 
+    _requires_usage_data = False
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -797,6 +838,8 @@ class RedEnergyBillingFrequencySensor(RedEnergyBaseSensor):
 class RedEnergyJurisdictionSensor(RedEnergyBaseSensor):
     """Red Energy jurisdiction sensor."""
 
+    _requires_usage_data = False
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -822,6 +865,8 @@ class RedEnergyJurisdictionSensor(RedEnergyBaseSensor):
 
 class RedEnergyChargeClassSensor(RedEnergyBaseSensor):
     """Red Energy charge class sensor (Energy Plan Type)."""
+
+    _requires_usage_data = False
 
     def __init__(
         self,
@@ -854,6 +899,8 @@ class RedEnergyChargeClassSensor(RedEnergyBaseSensor):
 
 class RedEnergyStatusSensor(RedEnergyBaseSensor):
     """Red Energy consumer status sensor."""
+
+    _requires_usage_data = False
 
     def __init__(
         self,

--- a/tests/test_sensor_basic_meter_disabled.py
+++ b/tests/test_sensor_basic_meter_disabled.py
@@ -1,0 +1,140 @@
+"""Test usage-dependent sensors default to disabled for BASIC/manual-read meters."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.red_energy.const import DOMAIN, SERVICE_TYPE_GAS, SERVICE_TYPE_ELECTRICITY
+from custom_components.red_energy.sensor import async_setup_entry
+
+
+def _coordinator_for_basic_gas_meter():
+    coordinator = MagicMock()
+    coordinator.data = {
+        "usage_data": {
+            "7471493": {
+                "property": {
+                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "services": [
+                        {
+                            "type": SERVICE_TYPE_GAS,
+                            "consumer_number": "gas-1",
+                            "meterType": "BASIC",
+                        }
+                    ],
+                },
+            },
+        }
+    }
+    coordinator.last_update_success = True
+
+    def get_service_metadata(property_id, service_type):
+        property_data = coordinator.data["usage_data"].get(str(property_id))
+        if not property_data:
+            return None
+        services = property_data["property"].get("services", [])
+        return next((s for s in services if s.get("type") == service_type), None)
+
+    coordinator.get_service_metadata = MagicMock(side_effect=get_service_metadata)
+    coordinator.get_service_usage = MagicMock(return_value=None)
+    return coordinator
+
+
+def _coordinator_for_interval_electricity_meter():
+    coordinator = MagicMock()
+    coordinator.data = {
+        "usage_data": {
+            "8490263": {
+                "property": {
+                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "services": [
+                        {
+                            "type": SERVICE_TYPE_ELECTRICITY,
+                            "consumer_number": "elec-1",
+                            "meterType": "INTERVAL",
+                        }
+                    ],
+                },
+            },
+        }
+    }
+    coordinator.last_update_success = True
+
+    def get_service_metadata(property_id, service_type):
+        property_data = coordinator.data["usage_data"].get(str(property_id))
+        if not property_data:
+            return None
+        services = property_data["property"].get("services", [])
+        return next((s for s in services if s.get("type") == service_type), None)
+
+    coordinator.get_service_metadata = MagicMock(side_effect=get_service_metadata)
+    coordinator.get_service_usage = MagicMock(return_value=None)
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_basic_meter_usage_sensors_disabled_by_default():
+    """Usage-dependent sensors for a BASIC meter must be disabled by default."""
+    coordinator = _coordinator_for_basic_gas_meter()
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["7471493"],
+                "services": [SERVICE_TYPE_GAS],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    assert added_entities, "Expected entities to be created"
+    for entity in added_entities:
+        if entity._requires_usage_data:
+            assert entity._attr_entity_registry_enabled_default is False, (
+                f"{entity.__class__.__name__} should default to disabled for a BASIC meter"
+            )
+        else:
+            assert getattr(entity, "_attr_entity_registry_enabled_default", True) is True, (
+                f"{entity.__class__.__name__} (metadata-only) should stay enabled"
+            )
+
+
+@pytest.mark.asyncio
+async def test_interval_meter_usage_sensors_stay_enabled():
+    """Usage-dependent sensors for a normal INTERVAL meter must stay enabled."""
+    coordinator = _coordinator_for_interval_electricity_meter()
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["8490263"],
+                "services": [SERVICE_TYPE_ELECTRICITY],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    assert added_entities, "Expected entities to be created"
+    for entity in added_entities:
+        assert getattr(entity, "_attr_entity_registry_enabled_default", True) is True, (
+            f"{entity.__class__.__name__} should stay enabled for an INTERVAL meter"
+        )


### PR DESCRIPTION
## Summary
- Bump version to 1.8.5
- A BASIC/manual-read meter (e.g. a gas account without a smart meter) never has interval usage data - Red Energy's `/usage/interval` endpoint returns a 400 for it on every single request, permanently (fixed in #39 to not create noisy ERROR logs or block device/entity creation for this). Those usage-dependent sensors were still enabled by default though, so they sat showing "Unknown" forever with no indication they'll never resolve.
- Usage-dependent sensors (import/export usage & cost, and all advanced sensors) now default to **disabled** for BASIC-metered accounts. Metadata-only sensors (NMI, meter type, solar, balance, arrears, bill dates, billing frequency, jurisdiction, charge class, status) stay enabled since they work regardless of meter type.
- Note: this only affects newly-created entities (HA's `entity_registry_enabled_default` only applies when an entity is first added to the registry) - entities that already exist and are enabled from a prior setup are unaffected by this change.