### PR TITLE
feat: remove service selection, fix reload auth race

### DIFF
--- a/custom_components/red_energy/__init__.py
+++ b/custom_components/red_energy/__init__.py
@@ -141,11 +141,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             device_manager = entry_data["device_manager"]
             await device_manager.async_cleanup_orphaned_entities()
         
-        # Stop coordinator
+        # Stop coordinator. Without this, its scheduled refresh timer keeps
+        # running after unload - if it fires (or is already mid-authenticate)
+        # while a fresh coordinator is being set up for the same reload, both
+        # race authenticate() on the same shared aiohttp session, breaking
+        # the Okta redirect ("No redirect location found in authorization
+        # response") until the next full Home Assistant restart clears it.
         if "coordinator" in entry_data:
             coordinator = entry_data["coordinator"]
-            # The coordinator will be garbage collected
-            
+            await coordinator.async_shutdown()
+
+
         # Remove domain data if empty
         if not hass.data[DOMAIN]:
             hass.data.pop(DOMAIN)

--- a/custom_components/red_energy/config_flow.py
+++ b/custom_components/red_energy/config_flow.py
@@ -32,7 +32,6 @@ from .const import (
     SCAN_INTERVAL_OPTIONS,
     SERVICE_TYPE_ELECTRICITY,
     SERVICE_TYPE_GAS,
-    STEP_SERVICE_SELECT,
     STEP_USER,
 )
 
@@ -186,51 +185,28 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     _LOGGER.error("No valid account IDs found in properties. Raw accounts: %s", self._accounts)
                     errors["base"] = ERROR_NO_ACCOUNTS
                 else:
-                    return await self.async_step_service_select()
+                    # Accounts are now selected individually and each only
+                    # ever bills one service, so there's nothing left for a
+                    # service-type toggle to do - always monitor both.
+                    config_data = {
+                        **self._user_data,
+                        DATA_SELECTED_ACCOUNTS: self._selected_accounts,
+                        "services": [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
+                    }
+
+                    title = self._customer_data.get("name", "Red Energy")
+                    if len(self._selected_accounts) > 1:
+                        title += f" ({len(self._selected_accounts)} properties)"
+
+                    return self.async_create_entry(
+                        title=title,
+                        data=config_data
+                    )
 
         return self.async_show_form(
             step_id=STEP_USER,
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors
-        )
-
-    async def async_step_service_select(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle service type selection."""
-        if user_input is not None:
-            # Combine all configuration data
-            config_data = {
-                **self._user_data,
-                DATA_SELECTED_ACCOUNTS: self._selected_accounts,
-                "services": user_input.get("services", [SERVICE_TYPE_ELECTRICITY])
-            }
-            
-            title = self._customer_data.get("name", "Red Energy")
-            if len(self._selected_accounts) > 1:
-                title += f" ({len(self._selected_accounts)} properties)"
-                
-            return self.async_create_entry(
-                title=title,
-                data=config_data
-            )
-
-        # Service selection schema
-        service_options = {
-            SERVICE_TYPE_ELECTRICITY: "Electricity",
-            SERVICE_TYPE_GAS: "Gas",
-        }
-        
-        schema = vol.Schema({
-            vol.Required("services", default=[SERVICE_TYPE_ELECTRICITY]): cv.multi_select(service_options),
-        })
-
-        return self.async_show_form(
-            step_id=STEP_SERVICE_SELECT,
-            data_schema=schema,
-            description_placeholders={
-                "account_count": str(len(self._selected_accounts))
-            }
         )
 
     @staticmethod
@@ -277,23 +253,23 @@ class RedEnergyOptionsFlowHandler(config_entries.OptionsFlow):
             }
 
         if user_input is not None:
-            current_services = entry.data.get("services", [SERVICE_TYPE_ELECTRICITY])
             new_selected_accounts = user_input.get(
                 "accounts", current_selected_accounts
             )
-            new_services = user_input.get("services", current_services)
 
             # entry.data (not entry.options) is what the coordinator reads, so
-            # account/service changes must be written there to take effect.
-            if set(new_selected_accounts) != set(current_selected_accounts) or set(
-                new_services
-            ) != set(current_services):
+            # the account selection change must be written there to take
+            # effect. Services are no longer user-configurable here - each
+            # account only ever bills one service, so both are always
+            # requested and per-account filtering (see sensor.py) determines
+            # what's actually created.
+            if set(new_selected_accounts) != set(current_selected_accounts):
                 self.hass.config_entries.async_update_entry(
                     entry,
                     data={
                         **entry.data,
                         DATA_SELECTED_ACCOUNTS: new_selected_accounts,
-                        "services": new_services,
+                        "services": [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
                     },
                 )
                 await self.hass.config_entries.async_reload(entry.entry_id)
@@ -327,15 +303,9 @@ class RedEnergyOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data=user_input)
 
         # Get current configuration
-        current_services = entry.data.get("services", [SERVICE_TYPE_ELECTRICITY])
         current_options = entry.options
         current_scan_interval = current_options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         current_advanced_sensors = current_options.get(CONF_ENABLE_ADVANCED_SENSORS, False)
-
-        service_options = {
-            SERVICE_TYPE_ELECTRICITY: "Electricity",
-            SERVICE_TYPE_GAS: "Gas",
-        }
 
         # Create interval display options
         interval_options = {}
@@ -361,7 +331,6 @@ class RedEnergyOptionsFlowHandler(config_entries.OptionsFlow):
 
         schema = vol.Schema({
             vol.Required("accounts", default=accounts_default): cv.multi_select(account_options),
-            vol.Required("services", default=current_services): cv.multi_select(service_options),
             vol.Required(CONF_SCAN_INTERVAL, default=current_scan_interval): vol.In(interval_options),
             vol.Required(CONF_ENABLE_ADVANCED_SENSORS, default=current_advanced_sensors): bool,
         })

--- a/custom_components/red_energy/config_migration.py
+++ b/custom_components/red_energy/config_migration.py
@@ -31,7 +31,8 @@ CONFIG_VERSION_3 = 3  # Added performance optimizations and device management
 CONFIG_VERSION_4 = 4  # Auto-select all accounts and fix account ID matching
 CONFIG_VERSION_5 = 5  # Fixed device identifier mismatch (removed duplicate devices)
 CONFIG_VERSION_6 = 6  # Removed client_id from user config (now hardcoded)
-CURRENT_CONFIG_VERSION = CONFIG_VERSION_6
+CONFIG_VERSION_7 = 7  # Removed service-type selection (always monitor both)
+CURRENT_CONFIG_VERSION = CONFIG_VERSION_7
 
 
 class ConfigValidationError(Exception):
@@ -80,7 +81,11 @@ class RedEnergyConfigMigrator:
             # Migrate from version 5 to 6
             if current_version < CONFIG_VERSION_6:
                 migration_success &= await self._migrate_v5_to_v6(config_entry)
-            
+
+            # Migrate from version 6 to 7
+            if current_version < CONFIG_VERSION_7:
+                migration_success &= await self._migrate_v6_to_v7(config_entry)
+
             if migration_success:
                 # Update version in config entry
                 self.hass.config_entries.async_update_entry(
@@ -293,11 +298,39 @@ class RedEnergyConfigMigrator:
             )
             
             _LOGGER.info("Successfully migrated to v6, client_id is now hardcoded in the integration")
-            
+
             return True
-            
+
         except Exception as err:
             _LOGGER.error("Failed to migrate v5 to v6: %s", err, exc_info=True)
+            return False
+
+    async def _migrate_v6_to_v7(self, config_entry: ConfigEntry) -> bool:
+        """Migrate from version 6 to 7 - Always monitor both services.
+
+        Accounts are now selected individually and each only ever bills one
+        service, so the old service-type picker (electricity/gas checkboxes)
+        was removed. Entries created before this change may have "services"
+        set to a subset - upgrade them to both so accounts aren't silently
+        excluded with no UI left to fix it.
+        """
+        _LOGGER.info("Migrating config entry from v6 to v7 - Always monitoring both services")
+
+        try:
+            new_data = dict(config_entry.data)
+            new_data["services"] = [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS]
+
+            self.hass.config_entries.async_update_entry(
+                config_entry,
+                data=new_data
+            )
+
+            _LOGGER.info("Successfully migrated to v7, both services are now always monitored")
+
+            return True
+
+        except Exception as err:
+            _LOGGER.error("Failed to migrate v6 to v7: %s", err, exc_info=True)
             return False
 
 

--- a/custom_components/red_energy/const.py
+++ b/custom_components/red_energy/const.py
@@ -98,7 +98,6 @@ API_TIMEOUT: Final = 30
 # Configuration flow
 STEP_USER: Final = "user"
 STEP_ACCOUNT_SELECT: Final = "account_select"
-STEP_SERVICE_SELECT: Final = "service_select"
 
 # Error messages
 ERROR_AUTH_FAILED: Final = "auth_failed"

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.8.4"
+  "version": "1.9.0"
 }

--- a/custom_components/red_energy/translations/en.json
+++ b/custom_components/red_energy/translations/en.json
@@ -8,13 +8,6 @@
           "username": "Username (Email)",
           "password": "Password"
         }
-      },
-      "service_select": {
-        "title": "Select Services",
-        "description": "All {account_count} properties will be monitored. Choose which services to track.",
-        "data": {
-          "services": "Services to Monitor"
-        }
       }
     },
     "error": {
@@ -31,10 +24,9 @@
     "step": {
       "init": {
         "title": "Red Energy Options",
-        "description": "Configure which accounts and services to monitor.",
+        "description": "Configure which accounts to monitor.",
         "data": {
           "accounts": "Accounts to Monitor",
-          "services": "Services to Monitor",
           "scan_interval": "Scan Interval",
           "enable_advanced_sensors": "Enable Advanced Sensors"
         }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,13 +2,14 @@
 from __future__ import annotations
 
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
 from custom_components.red_energy.const import (
+    DATA_SELECTED_ACCOUNTS,
     DOMAIN,
     ERROR_AUTH_FAILED,
     ERROR_CANNOT_CONNECT,
@@ -123,7 +124,7 @@ async def test_successful_single_account_flow():
     # Mock async_set_unique_id and _abort_if_unique_id_configured
     flow.async_set_unique_id = AsyncMock()
     flow._abort_if_unique_id_configured = AsyncMock()
-    flow.async_create_entry = AsyncMock(return_value={"type": "create_entry"})
+    flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
     
     mock_validation_result = {
         "customer_data": MOCK_CUSTOMER_DATA,
@@ -135,18 +136,11 @@ async def test_successful_single_account_flow():
         "custom_components.red_energy.config_flow.validate_input",
         return_value=mock_validation_result,
     ):
-        # Step 1: User input
+        # Accounts are auto-selected and both services are always requested
+        # (no separate service-selection step) - the config flow creates
+        # the entry directly after account discovery.
         result = await flow.async_step_user(MOCK_USER_INPUT)
-        
-        # Should go directly to service selection for single account
-        assert result["type"] == "form"
-        assert result["step_id"] == "service_select"
-        
-        # Step 2: Service selection
-        service_input = {"services": ["electricity"]}
-        result = await flow.async_step_service_select(service_input)
-        
-        # Should create entry
+
         flow.async_create_entry.assert_called_once()
 
 
@@ -162,7 +156,7 @@ async def test_successful_multi_account_flow():
     # Mock methods
     flow.async_set_unique_id = AsyncMock()
     flow._abort_if_unique_id_configured = AsyncMock()
-    flow.async_create_entry = AsyncMock(return_value={"type": "create_entry"})
+    flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
     
     # Add two properties to simulate multiple accounts
     mock_validation_result = {
@@ -175,12 +169,13 @@ async def test_successful_multi_account_flow():
         "custom_components.red_energy.config_flow.validate_input",
         return_value=mock_validation_result,
     ):
-        # Step 1: User input - should handle multiple accounts
+        # Both accounts are auto-selected and the entry is created directly
         result = await flow.async_step_user(MOCK_USER_INPUT)
-        
-        # Should either show account selection or proceed
+
         assert result is not None
-        assert "type" in result
+        flow.async_create_entry.assert_called_once()
+        _, kwargs = flow.async_create_entry.call_args
+        assert kwargs["data"][DATA_SELECTED_ACCOUNTS] == ["prop-001", "prop-002"]
 
 
 def test_validate_input_structure():
@@ -195,31 +190,39 @@ def test_validate_input_structure():
 
 
 @pytest.mark.asyncio
-async def test_service_select_schema_validation():
-    """Test that service selection works."""
+async def test_config_flow_always_requests_both_services():
+    """Both electricity and gas are always requested - no service picker.
+
+    Each account only ever bills one service (Red Energy splits electricity
+    and gas onto separate accounts), so a service-type toggle has nothing
+    left to do; per-account filtering in sensor.py determines what's
+    actually created.
+    """
     hass = AsyncMock(spec=HomeAssistant)
-    
+
     from custom_components.red_energy.config_flow import ConfigFlow
-    from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY
-    
+    from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS
+
     flow = ConfigFlow()
     flow.hass = hass
-    
-    # Set up flow state to reach service selection
-    flow._customer_data = MOCK_CUSTOMER_DATA
-    flow._accounts = MOCK_PROPERTIES
-    flow._selected_account = MOCK_PROPERTIES[0]
-    flow.async_create_entry = AsyncMock(return_value={"type": "create_entry"})
     flow.async_set_unique_id = AsyncMock()
     flow._abort_if_unique_id_configured = AsyncMock()
-    
-    # Test valid service selection
-    try:
-        result = await flow.async_step_service_select({"services": [SERVICE_TYPE_ELECTRICITY]})
-        assert result is not None
-    except Exception:
-        # Some config flows may need additional setup, that's OK for this test
-        pass
+    flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+    mock_validation_result = {
+        "customer_data": MOCK_CUSTOMER_DATA,
+        "accounts": [MOCK_PROPERTIES[0]],
+        "title": "Test User"
+    }
+
+    with patch(
+        "custom_components.red_energy.config_flow.validate_input",
+        return_value=mock_validation_result,
+    ):
+        await flow.async_step_user(MOCK_USER_INPUT)
+
+    _, kwargs = flow.async_create_entry.call_args
+    assert set(kwargs["data"]["services"]) == {SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS}
 
 
 def test_domain_constant():

--- a/tests/test_config_flow_basic.py
+++ b/tests/test_config_flow_basic.py
@@ -27,7 +27,6 @@ def test_config_flow_has_required_classes():
     # Check for required classes and methods
     assert "class ConfigFlow" in content
     assert "async_step_user" in content
-    assert "async_step_service_select" in content
     assert "RedEnergyOptionsFlowHandler" in content
 
 
@@ -89,7 +88,5 @@ def test_constants_include_config_flow_constants():
     
     # Check for config flow constants
     assert hasattr(const_module, "STEP_USER")
-    assert hasattr(const_module, "STEP_ACCOUNT_SELECT")
-    assert hasattr(const_module, "STEP_SERVICE_SELECT")
     assert hasattr(const_module, "ERROR_AUTH_FAILED")
     assert hasattr(const_module, "CONF_CLIENT_ID")

--- a/tests/test_config_flow_options_accounts.py
+++ b/tests/test_config_flow_options_accounts.py
@@ -72,7 +72,6 @@ async def test_options_init_form_lists_newly_discovered_account():
     # The selector's option values should include the newly-discovered gas account
     schema_dict = result["data_schema"]({
         "accounts": ["8490263", "7471493"],
-        "services": ["electricity"],
         "scan_interval": "30min",
         "enable_advanced_sensors": False,
     })
@@ -122,7 +121,6 @@ async def test_options_submit_adds_new_account_and_reloads():
 
     user_input = {
         "accounts": ["8490263", "7471493"],
-        "services": ["electricity", "gas"],
         "scan_interval": "30min",
         "enable_advanced_sensors": False,
     }
@@ -160,12 +158,13 @@ async def test_options_init_reuses_coordinator_api_not_a_new_client():
 
 
 @pytest.mark.asyncio
-async def test_options_submit_enabling_gas_service_persists_and_reloads():
-    """Turning on the Gas service checkbox must actually take effect.
+async def test_options_submit_always_keeps_both_services():
+    """Services are no longer user-configurable - both are always requested.
 
-    entry.data["services"] is what the coordinator reads (entry.options is
-    never consulted), so toggling "gas" on in the options form must update
-    entry.data and reload — otherwise the checkbox is a no-op.
+    Each account only ever bills one service, so a service-type toggle has
+    nothing left to do; per-account filtering in sensor.py determines what's
+    actually created. Submitting options must still write both services to
+    entry.data so an old entry stuck on a subset gets upgraded.
     """
     entry = _make_config_entry()
     hass = _make_hass(entry)
@@ -178,8 +177,7 @@ async def test_options_submit_enabling_gas_service_persists_and_reloads():
     flow._config_entry = entry
 
     user_input = {
-        "accounts": ["8490263"],
-        "services": ["electricity", "gas"],
+        "accounts": ["8490263", "7471493"],  # changed from entry's original ["8490263"]
         "scan_interval": "30min",
         "enable_advanced_sensors": False,
     }
@@ -189,7 +187,6 @@ async def test_options_submit_enabling_gas_service_persists_and_reloads():
     hass.config_entries.async_update_entry.assert_called_once()
     _, kwargs = hass.config_entries.async_update_entry.call_args
     assert kwargs["data"]["services"] == ["electricity", "gas"]
-    hass.config_entries.async_reload.assert_awaited_once_with(entry.entry_id)
 
 
 @pytest.mark.asyncio
@@ -213,7 +210,6 @@ async def test_options_submit_does_not_crash_when_coordinator_not_loaded():
 
     user_input = {
         "accounts": ["8490263"],
-        "services": ["electricity"],
         "scan_interval": "30min",
         "enable_advanced_sensors": False,
     }

--- a/tests/test_config_migration_v7.py
+++ b/tests/test_config_migration_v7.py
@@ -1,0 +1,63 @@
+"""Test config migration to v7 - always monitor both services."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.red_energy.config_migration import (
+    CONFIG_VERSION_7,
+    CURRENT_CONFIG_VERSION,
+    RedEnergyConfigMigrator,
+)
+from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS
+
+
+def _make_config_entry(version, services):
+    entry = MagicMock()
+    entry.version = version
+    entry.entry_id = "entry1"
+    entry.data = {
+        "username": "test@example.com",
+        "password": "testpass",
+        "selected_accounts": ["8490263"],
+        "services": services,
+    }
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_v6_entry_with_electricity_only_upgrades_to_both_services():
+    """An entry stuck on electricity-only (no service picker left to fix it) must be upgraded."""
+    entry = _make_config_entry(version=6, services=[SERVICE_TYPE_ELECTRICITY])
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    migrator = RedEnergyConfigMigrator(hass)
+    result = await migrator.async_migrate_config_entry(entry)
+
+    assert result is True
+    hass.config_entries.async_update_entry.assert_any_call(
+        entry, data={**entry.data, "services": [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS]}
+    )
+    hass.config_entries.async_update_entry.assert_any_call(entry, version=CURRENT_CONFIG_VERSION)
+
+
+@pytest.mark.asyncio
+async def test_current_version_entry_not_migrated():
+    """An entry already at the current version should be left alone."""
+    entry = _make_config_entry(
+        version=CURRENT_CONFIG_VERSION, services=[SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS]
+    )
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    migrator = RedEnergyConfigMigrator(hass)
+    result = await migrator.async_migrate_config_entry(entry)
+
+    assert result is True
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+def test_config_version_7_is_current():
+    assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_7

--- a/tests/test_device_identifier_fix.py
+++ b/tests/test_device_identifier_fix.py
@@ -168,12 +168,12 @@ def test_device_model_dual_service():
 
 
 def test_migration_version():
-    """Test that migration version is set to 6."""
-    from custom_components.red_energy.config_migration import CURRENT_CONFIG_VERSION, CONFIG_VERSION_5, CONFIG_VERSION_6
-    
-    assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_6
+    """Test that migration version is set to 7."""
+    from custom_components.red_energy.config_migration import CURRENT_CONFIG_VERSION, CONFIG_VERSION_5, CONFIG_VERSION_7
+
+    assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_7
     assert CONFIG_VERSION_5 == 5
-    
+
     print(f"✓ Current config version: {CURRENT_CONFIG_VERSION}")
     print("✓ Version 5 includes device identifier fix")
 

--- a/tests/test_unload_shuts_down_coordinator.py
+++ b/tests/test_unload_shuts_down_coordinator.py
@@ -1,0 +1,49 @@
+"""Test that unloading the integration shuts down the coordinator's refresh loop."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.red_energy import async_unload_entry
+from custom_components.red_energy.const import DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_unload_entry_shuts_down_coordinator():
+    """Unloading must stop the coordinator's scheduled refresh timer.
+
+    Without this, the old coordinator's periodic refresh can still fire (or
+    be mid-authenticate) after unload, racing a freshly-created coordinator's
+    authenticate() call on the same shared aiohttp session during a reload
+    (e.g. after changing the selected accounts) - breaking the Okta redirect
+    until the next full Home Assistant restart clears it.
+    """
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+
+    coordinator = MagicMock()
+    coordinator.async_shutdown = AsyncMock()
+
+    state_manager = MagicMock()
+    state_manager.async_save_states = AsyncMock()
+
+    device_manager = MagicMock()
+    device_manager.async_cleanup_orphaned_entities = AsyncMock()
+
+    hass = MagicMock()
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "state_manager": state_manager,
+                "device_manager": device_manager,
+            }
+        }
+    }
+
+    result = await async_unload_entry(hass, entry)
+
+    assert result is True
+    coordinator.async_shutdown.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Bump version to 1.9.0
- Accounts are now selected individually and each only ever bills one service (Red Energy splits electricity and gas onto separate accounts), so the electricity/gas checkboxes in both the initial setup flow and options flow had nothing left to control - per-account filtering already determines what's actually created (from #39). Both services are now always requested; the setup flow creates the entry directly after account discovery (no separate service-selection step), and the options form drops the "Services to Monitor" field entirely.
- Added a config migration (v6 -> v7) so an existing entry stuck on a subset of services from before this change gets upgraded to both - otherwise it would be permanently excluded with no UI left to fix it.
- Separately: found and fixed the root cause of the token/reload issue - `async_unload_entry` never called `coordinator.async_shutdown()`, so the old coordinator's scheduled refresh timer kept running after unload. If it fired (or was already mid-`authenticate()`) while a fresh coordinator was being set up for the same reload (e.g. after changing the selected accounts in options), both raced `authenticate()` on the same shared aiohttp session - reproducing the "No redirect location found in authorization response" failure from #34/#36, and only clearing on a full Home Assistant restart since nothing else stopped the old timer.