### PR TITLE
fix: electricity-only sensors, entity naming, new diagnostics

### DIFF
--- a/custom_components/red_energy/const.py
+++ b/custom_components/red_energy/const.py
@@ -78,6 +78,8 @@ SENSOR_TYPE_BILLING_FREQUENCY: Final = "billing_frequency"
 SENSOR_TYPE_JURISDICTION: Final = "jurisdiction"
 SENSOR_TYPE_CHARGE_CLASS: Final = "charge_class"
 SENSOR_TYPE_STATUS: Final = "status"
+SENSOR_TYPE_ADDRESS: Final = "address"
+SENSOR_TYPE_PAYMENT_TYPE: Final = "payment_type"
 
 # Configuration options
 CONF_SCAN_INTERVAL: Final = "scan_interval"

--- a/custom_components/red_energy/data_validation.py
+++ b/custom_components/red_energy/data_validation.py
@@ -256,7 +256,16 @@ def validate_single_service(data: Dict[str, Any]) -> Dict[str, Any]:
     for field in metadata_fields:
         if field in data:
             validated_service[field] = data[field]
-    
+
+    # Nested fields not covered by the flat allowlist above
+    payment_type_detail = data.get("paymentTypeDetail")
+    if isinstance(payment_type_detail, dict) and payment_type_detail.get("paymentTypeDescription"):
+        validated_service["paymentTypeDescription"] = payment_type_detail["paymentTypeDescription"]
+
+    current_plan = data.get("currentPlan")
+    if isinstance(current_plan, dict) and current_plan.get("promotionDesc"):
+        validated_service["promotionDesc"] = current_plan["promotionDesc"]
+
     return validated_service
 
 

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.9.0"
+  "version": "1.10.0"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.util import dt as dt_util
 from .const import (
     CONF_ENABLE_ADVANCED_SENSORS,
     DOMAIN,
+    SENSOR_TYPE_ADDRESS,
     SENSOR_TYPE_ARREARS,
     SENSOR_TYPE_BALANCE,
     SENSOR_TYPE_BILLING_FREQUENCY,
@@ -35,6 +36,7 @@ from .const import (
     SENSOR_TYPE_MONTHLY_AVERAGE,
     SENSOR_TYPE_NEXT_BILL_DATE,
     SENSOR_TYPE_NMI,
+    SENSOR_TYPE_PAYMENT_TYPE,
     SENSOR_TYPE_PEAK_USAGE,
     SENSOR_TYPE_PRODUCT_NAME,
     SENSOR_TYPE_SOLAR,
@@ -104,6 +106,8 @@ async def async_setup_entry(
                 RedEnergyJurisdictionSensor(coordinator, config_entry, account_id, service_type),
                 RedEnergyChargeClassSensor(coordinator, config_entry, account_id, service_type),
                 RedEnergyStatusSensor(coordinator, config_entry, account_id, service_type),
+                RedEnergyAddressSensor(coordinator, config_entry, account_id, service_type),
+                RedEnergyPaymentTypeSensor(coordinator, config_entry, account_id, service_type),
                 # Daily import/export usage breakdown
                 RedEnergyDailyImportUsageSensor(coordinator, config_entry, account_id, service_type),
                 RedEnergyDailyExportUsageSensor(coordinator, config_entry, account_id, service_type),
@@ -144,6 +148,14 @@ async def async_setup_entry(
                 for entity in service_entities:
                     if entity._requires_usage_data:
                         entity._attr_entity_registry_enabled_default = False
+
+            # Solar, export, time-of-use breakdown, demand, carbon emission,
+            # and efficiency have no equivalent for gas - drop them entirely
+            # rather than creating a permanently meaningless entity.
+            if service_type != SERVICE_TYPE_ELECTRICITY:
+                service_entities = [
+                    entity for entity in service_entities if not entity._electricity_only
+                ]
 
             entities.extend(service_entities)
     
@@ -194,6 +206,12 @@ class RedEnergyBaseSensor(CoordinatorEntity, SensorEntity):
     # False since they work regardless of meter type.
     _requires_usage_data: bool = True
 
+    # Whether this sensor is only meaningful for electricity: solar, export,
+    # time-of-use breakdown, demand, carbon emission, and efficiency have no
+    # equivalent for gas, which is one-directional and has no ToU tariff.
+    # Not created at all for gas accounts (see async_setup_entry).
+    _electricity_only: bool = False
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -210,9 +228,10 @@ class RedEnergyBaseSensor(CoordinatorEntity, SensorEntity):
         self._service_type = service_type
         self._sensor_type = sensor_type
 
-        service_display = service_type.title()
-
-        self._attr_name = f"{property_id} {service_display} {sensor_type.replace('_', ' ').title()}"
+        # No account_id/service prefix here - the device (named "{account_id}
+        # - {Service}", see device_manager.py) already conveys both, and HA
+        # shows device name + entity name together in the UI.
+        self._attr_name = sensor_type.replace('_', ' ').title()
         self._attr_unique_id = f"{DOMAIN}_{config_entry.entry_id}_{property_id}_{service_type}_{sensor_type}"
         
         # Set device info for grouping (device_manager handles full device metadata)
@@ -461,6 +480,8 @@ class RedEnergyPeakUsageSensor(RedEnergyBaseSensor):
 class RedEnergyEfficiencySensor(RedEnergyBaseSensor):
     """Red Energy efficiency rating sensor."""
 
+    _electricity_only = True
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -589,6 +610,7 @@ class RedEnergySolarSensor(RedEnergyBaseSensor):
     """Red Energy solar capability sensor."""
 
     _requires_usage_data = False
+    _electricity_only = True
 
     def __init__(
         self,
@@ -638,8 +660,21 @@ class RedEnergyProductNameSensor(RedEnergyBaseSensor):
         metadata = self.coordinator.get_service_metadata(self._property_id, self._service_type)
         if not metadata:
             return None
-        
+
         return metadata.get("productName")
+
+    @property
+    def extra_state_attributes(self) -> Optional[dict[str, Any]]:
+        """Return extra state attributes."""
+        metadata = self.coordinator.get_service_metadata(self._property_id, self._service_type)
+        if not metadata:
+            return None
+
+        promotion_desc = metadata.get("promotionDesc")
+        if not promotion_desc:
+            return None
+
+        return {"promotion_description": promotion_desc}
 
 
 class RedEnergyDistributorSensor(RedEnergyBaseSensor):
@@ -666,8 +701,75 @@ class RedEnergyDistributorSensor(RedEnergyBaseSensor):
         metadata = self.coordinator.get_service_metadata(self._property_id, self._service_type)
         if not metadata:
             return None
-        
+
         return metadata.get("linesCompany")
+
+
+class RedEnergyPaymentTypeSensor(RedEnergyBaseSensor):
+    """Red Energy payment type sensor."""
+
+    _requires_usage_data = False
+
+    def __init__(
+        self,
+        coordinator: RedEnergyDataCoordinator,
+        config_entry: ConfigEntry,
+        property_id: str,
+        service_type: str,
+    ) -> None:
+        """Initialize the payment type sensor."""
+        super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_PAYMENT_TYPE)
+
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_icon = "mdi:credit-card-outline"
+
+    @property
+    def native_value(self) -> Optional[str]:
+        """Return the payment type description."""
+        metadata = self.coordinator.get_service_metadata(self._property_id, self._service_type)
+        if not metadata:
+            return None
+
+        return metadata.get("paymentTypeDescription")
+
+
+class RedEnergyAddressSensor(RedEnergyBaseSensor):
+    """Red Energy property address sensor."""
+
+    _requires_usage_data = False
+
+    def __init__(
+        self,
+        coordinator: RedEnergyDataCoordinator,
+        config_entry: ConfigEntry,
+        property_id: str,
+        service_type: str,
+    ) -> None:
+        """Initialize the address sensor."""
+        super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_ADDRESS)
+
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_icon = "mdi:map-marker"
+
+    @property
+    def native_value(self) -> Optional[str]:
+        """Return the formatted property address."""
+        property_data = self.coordinator.get_property_data(self._property_id)
+        if not property_data:
+            return None
+
+        address = property_data.get("property", {}).get("address", {})
+        parts = [
+            address.get("street"),
+            address.get("city"),
+            address.get("state"),
+            address.get("postcode"),
+        ]
+        formatted = ", ".join(p for p in parts[:2] if p)
+        state_postcode = " ".join(p for p in parts[2:] if p)
+        if formatted and state_postcode:
+            return f"{formatted} {state_postcode}"
+        return formatted or state_postcode or None
 
 
 class RedEnergyBalanceSensor(RedEnergyBaseSensor):
@@ -880,7 +982,7 @@ class RedEnergyChargeClassSensor(RedEnergyBaseSensor):
         
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_icon = "mdi:tag"
-        self._attr_name = f"{self._attr_name.rsplit(' ', 1)[0]} Energy Plan Type"
+        self._attr_name = "Energy Plan Type"
 
     @property
     def native_value(self) -> Optional[str]:
@@ -982,6 +1084,8 @@ class RedEnergyDailyImportUsageSensor(RedEnergyBaseSensor):
 class RedEnergyDailyExportUsageSensor(RedEnergyBaseSensor):
     """Red Energy daily export usage sensor (solar generation)."""
 
+    _electricity_only = True
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -1078,6 +1182,8 @@ class RedEnergyTotalImportUsageSensor(RedEnergyBaseSensor):
 
 class RedEnergyTotalExportUsageSensor(RedEnergyBaseSensor):
     """Red Energy total export usage sensor (30-day period)."""
+
+    _electricity_only = True
 
     def __init__(
         self,
@@ -1178,6 +1284,8 @@ class RedEnergyTotalImportCostSensor(RedEnergyBaseSensor):
 class RedEnergyTotalExportCreditSensor(RedEnergyBaseSensor):
     """Red Energy total export credit sensor."""
 
+    _electricity_only = True
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -1260,6 +1368,8 @@ class RedEnergyDailyImportCostSensor(RedEnergyBaseSensor):
 class RedEnergyDailyExportCreditSensor(RedEnergyBaseSensor):
     """Red Energy daily export credit sensor."""
 
+    _electricity_only = True
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -1297,6 +1407,8 @@ class RedEnergyDailyExportCreditSensor(RedEnergyBaseSensor):
 
 class RedEnergyPeakImportUsageSensor(RedEnergyBaseSensor):
     """Red Energy peak import usage sensor."""
+
+    _electricity_only = True
 
     def __init__(
         self,
@@ -1339,6 +1451,8 @@ class RedEnergyPeakImportUsageSensor(RedEnergyBaseSensor):
 class RedEnergyOffpeakImportUsageSensor(RedEnergyBaseSensor):
     """Red Energy offpeak import usage sensor."""
 
+    _electricity_only = True
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -1380,6 +1494,8 @@ class RedEnergyOffpeakImportUsageSensor(RedEnergyBaseSensor):
 class RedEnergyShoulderImportUsageSensor(RedEnergyBaseSensor):
     """Red Energy shoulder import usage sensor."""
 
+    _electricity_only = True
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -1420,6 +1536,8 @@ class RedEnergyShoulderImportUsageSensor(RedEnergyBaseSensor):
 
 class RedEnergyPeakExportUsageSensor(RedEnergyBaseSensor):
     """Red Energy peak export usage sensor."""
+
+    _electricity_only = True
 
     def __init__(
         self,
@@ -1464,6 +1582,8 @@ class RedEnergyPeakExportUsageSensor(RedEnergyBaseSensor):
 class RedEnergyOffpeakExportUsageSensor(RedEnergyBaseSensor):
     """Red Energy offpeak export usage sensor."""
 
+    _electricity_only = True
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -1506,6 +1626,8 @@ class RedEnergyOffpeakExportUsageSensor(RedEnergyBaseSensor):
 
 class RedEnergyShoulderExportUsageSensor(RedEnergyBaseSensor):
     """Red Energy shoulder export usage sensor."""
+
+    _electricity_only = True
 
     def __init__(
         self,
@@ -1550,6 +1672,8 @@ class RedEnergyShoulderExportUsageSensor(RedEnergyBaseSensor):
 class RedEnergyMaxDemandSensor(RedEnergyBaseSensor):
     """Red Energy maximum demand sensor."""
 
+    _electricity_only = True
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -1590,6 +1714,8 @@ class RedEnergyMaxDemandSensor(RedEnergyBaseSensor):
 class RedEnergyMaxDemandTimeSensor(RedEnergyBaseSensor):
     """Red Energy maximum demand timestamp sensor."""
 
+    _electricity_only = True
+
     def __init__(
         self,
         coordinator: RedEnergyDataCoordinator,
@@ -1599,9 +1725,13 @@ class RedEnergyMaxDemandTimeSensor(RedEnergyBaseSensor):
     ) -> None:
         """Initialize the maximum demand timestamp sensor."""
         super().__init__(coordinator, config_entry, property_id, service_type, "max_demand_interval_start")
-        
+
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
         self._attr_icon = "mdi:clock-alert"
+        # Rarely useful on its own (the value it timestamps - max demand -
+        # is the primary sensor) and often has no value even when usage data
+        # exists, so it's disabled by default rather than always enabled.
+        self._attr_entity_registry_enabled_default = False
 
     @property
     def native_value(self) -> Optional[datetime]:
@@ -1618,6 +1748,8 @@ class RedEnergyMaxDemandTimeSensor(RedEnergyBaseSensor):
 
 class RedEnergyCarbonEmissionSensor(RedEnergyBaseSensor):
     """Red Energy carbon emission sensor."""
+
+    _electricity_only = True
 
     def __init__(
         self,

--- a/tests/test_data_validation_errors.py
+++ b/tests/test_data_validation_errors.py
@@ -5,6 +5,7 @@ from custom_components.red_energy.data_validation import (
     validate_usage_entry,
     validate_address,
     validate_properties_data,
+    validate_single_service,
     DataValidationError
 )
 
@@ -349,3 +350,45 @@ def test_validate_properties_data_handles_address_with_none_house():
     assert result[0]["address"]["city"] == "CASTLECRAG"
     assert result[0]["address"]["state"] == "NSW"
     assert result[0]["address"]["postcode"] == "2068"
+
+
+def test_validate_single_service_extracts_payment_type_description():
+    """paymentTypeDetail.paymentTypeDescription must surface as a flat field."""
+    raw_service = {
+        "utility": "G",
+        "consumerNumber": "4236257811",
+        "status": "ON",
+        "paymentTypeDetail": {
+            "paymentType": "DDB",
+            "paymentTypeDescription": "DirectDebit Bank",
+        },
+    }
+    result = validate_single_service(raw_service)
+    assert result["paymentTypeDescription"] == "DirectDebit Bank"
+
+
+def test_validate_single_service_extracts_promotion_desc():
+    """currentPlan.promotionDesc must surface as a flat field."""
+    raw_service = {
+        "utility": "E",
+        "consumerNumber": "4235478511",
+        "status": "ON",
+        "currentPlan": {
+            "promotionCode": "NEQ005",
+            "promotionDesc": "Qantas Red Saver, 2 QFF Points per $1",
+        },
+    }
+    result = validate_single_service(raw_service)
+    assert result["promotionDesc"] == "Qantas Red Saver, 2 QFF Points per $1"
+
+
+def test_validate_single_service_missing_nested_fields_omitted():
+    """Missing paymentTypeDetail/currentPlan must not add empty keys."""
+    raw_service = {
+        "utility": "G",
+        "consumerNumber": "4236257811",
+        "status": "ON",
+    }
+    result = validate_single_service(raw_service)
+    assert "paymentTypeDescription" not in result
+    assert "promotionDesc" not in result

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -142,11 +142,12 @@ class TestSensorDisplayNames:
         assert "Daily Import Usage" in sensor._attr_name
         assert "_" not in sensor._attr_name.split(" ")[-3:]  # Check last 3 words don't have underscores
 
-    def test_base_sensor_name_uses_property_id_not_property_display_name(self):
-        """Entity names use the account/property ID, not the address-derived property name.
+    def test_base_sensor_name_has_no_account_or_service_prefix(self):
+        """Entity names carry no account_id/service prefix and no address.
 
-        Split accounts (e.g. electricity and gas billed separately) can share
-        the same address, so the address alone doesn't distinguish entities.
+        The device (named "{account_id} - {Service}") already conveys both,
+        and Home Assistant shows device name + entity name together in the
+        UI, so repeating them in every entity name is redundant.
         """
         coordinator = create_mock_coordinator()
         config_entry = create_mock_config_entry()
@@ -159,7 +160,8 @@ class TestSensorDisplayNames:
             "daily_import_usage"
         )
 
-        assert sensor._attr_name.startswith("prop-001")
+        assert sensor._attr_name == "Daily Import Usage"
+        assert "prop-001" not in sensor._attr_name
         assert "Test Property" not in sensor._attr_name
 
     def test_total_cost_sensor_display_name(self):

--- a/tests/test_sensor_electricity_only_and_diagnostics.py
+++ b/tests/test_sensor_electricity_only_and_diagnostics.py
@@ -1,0 +1,188 @@
+"""Test electricity-only sensor gating, new diagnostic sensors, and attributes."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.red_energy.const import DOMAIN, SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS
+from custom_components.red_energy.sensor import (
+    RedEnergyAddressSensor,
+    RedEnergyMaxDemandTimeSensor,
+    RedEnergyPaymentTypeSensor,
+    RedEnergyProductNameSensor,
+    RedEnergySolarSensor,
+    async_setup_entry,
+)
+
+GAS_SERVICE_METADATA = {
+    "type": SERVICE_TYPE_GAS,
+    "consumer_number": "gas-1",
+    "meterType": "INTERVAL",
+    "solar": False,
+    "paymentTypeDescription": "DirectDebit Bank",
+    "promotionDesc": "Qantas Red Saver, 2 QFF Points per $1",
+}
+
+ELECTRICITY_SERVICE_METADATA = {
+    "type": SERVICE_TYPE_ELECTRICITY,
+    "consumer_number": "elec-1",
+    "meterType": "INTERVAL",
+    "solar": True,
+    "paymentTypeDescription": "DirectDebit Bank",
+    "promotionDesc": "Qantas Red Saver, 2 QFF Points per $1",
+}
+
+
+def _coordinator(service_metadata, service_type):
+    coordinator = MagicMock()
+    coordinator.data = {
+        "usage_data": {
+            "7471493": {
+                "property": {
+                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "address": {
+                        "street": "27 Sunnyside Crescent",
+                        "city": "Castlecrag",
+                        "state": "NSW",
+                        "postcode": "2068",
+                    },
+                    "services": [service_metadata],
+                },
+            },
+        }
+    }
+    coordinator.last_update_success = True
+    coordinator.get_property_data = MagicMock(
+        side_effect=lambda pid: coordinator.data["usage_data"].get(str(pid))
+    )
+
+    def get_service_metadata(property_id, svc_type):
+        property_data = coordinator.data["usage_data"].get(str(property_id))
+        if not property_data:
+            return None
+        services = property_data["property"].get("services", [])
+        return next((s for s in services if s.get("type") == svc_type), None)
+
+    coordinator.get_service_metadata = MagicMock(side_effect=get_service_metadata)
+    coordinator.get_service_usage = MagicMock(return_value=None)
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_electricity_only_sensors_not_created_for_gas_account():
+    """Solar, export, ToU breakdown, demand, carbon emission, efficiency must not exist for gas."""
+    coordinator = _coordinator(GAS_SERVICE_METADATA, SERVICE_TYPE_GAS)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {"enable_advanced_sensors": True}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["7471493"],
+                "services": [SERVICE_TYPE_GAS],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    electricity_only_present = [e for e in added_entities if e._electricity_only]
+    assert electricity_only_present == [], (
+        f"Electricity-only sensors created for gas account: "
+        f"{[e.__class__.__name__ for e in electricity_only_present]}"
+    )
+    assert not any(isinstance(e, RedEnergySolarSensor) for e in added_entities)
+
+
+@pytest.mark.asyncio
+async def test_electricity_only_sensors_created_for_electricity_account():
+    """The same sensors must still exist for an electricity account."""
+    coordinator = _coordinator(ELECTRICITY_SERVICE_METADATA, SERVICE_TYPE_ELECTRICITY)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {"enable_advanced_sensors": True}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["7471493"],
+                "services": [SERVICE_TYPE_ELECTRICITY],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    assert any(isinstance(e, RedEnergySolarSensor) for e in added_entities)
+
+
+@pytest.mark.asyncio
+async def test_max_demand_time_disabled_by_default():
+    """The Max Demand Interval Start sensor must default to disabled."""
+    coordinator = _coordinator(ELECTRICITY_SERVICE_METADATA, SERVICE_TYPE_ELECTRICITY)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {"enable_advanced_sensors": True}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["7471493"],
+                "services": [SERVICE_TYPE_ELECTRICITY],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    max_demand_time = next(e for e in added_entities if isinstance(e, RedEnergyMaxDemandTimeSensor))
+    assert max_demand_time._attr_entity_registry_enabled_default is False
+
+
+def test_address_sensor_formats_full_address():
+    coordinator = _coordinator(GAS_SERVICE_METADATA, SERVICE_TYPE_GAS)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+
+    sensor = RedEnergyAddressSensor(coordinator, config_entry, "7471493", SERVICE_TYPE_GAS)
+
+    assert sensor.native_value == "27 Sunnyside Crescent, Castlecrag NSW 2068"
+
+
+def test_payment_type_sensor_returns_description():
+    coordinator = _coordinator(GAS_SERVICE_METADATA, SERVICE_TYPE_GAS)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+
+    sensor = RedEnergyPaymentTypeSensor(coordinator, config_entry, "7471493", SERVICE_TYPE_GAS)
+
+    assert sensor.native_value == "DirectDebit Bank"
+
+
+def test_energy_plan_sensor_exposes_promotion_desc_attribute():
+    coordinator = _coordinator(GAS_SERVICE_METADATA, SERVICE_TYPE_GAS)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+
+    sensor = RedEnergyProductNameSensor(coordinator, config_entry, "7471493", SERVICE_TYPE_GAS)
+
+    assert sensor.extra_state_attributes == {
+        "promotion_description": "Qantas Red Saver, 2 QFF Points per $1"
+    }


### PR DESCRIPTION
## Summary
- Bump version to 1.10.0
- **Merged #40 into main first** - it had never actually been merged despite CI passing; discovered this while starting today's work and resolved a manifest version conflict along the way.
- Solar, export usage/credit, time-of-use breakdown (peak/offpeak/shoulder import & export), max demand, carbon emission, and efficiency have no equivalent for gas - it's one-directional with no ToU tariff - but were being created for gas accounts anyway (e.g. a permanently "No" Solar entity under the gas device). These 15 sensor classes are now skipped entirely for non-electricity accounts.
- Removed the `"{account_id} {Service}"` prefix from every entity name - the device (named `"{account_id} - {Service}"`) already conveys both, and HA shows device + entity name together in the UI.
- Max Demand Interval Start now defaults to disabled (rarely useful standalone, often has no value even when Max Demand itself does).
- New "Address" diagnostic sensor (the account's property address).
- New "Payment Type" diagnostic sensor (`paymentTypeDetail.paymentTypeDescription`).
- "Energy Plan" sensor now exposes `currentPlan.promotionDesc` as a `promotion_description` attribute.