### PR TITLE
feat: add diagnostic sensors for tariff rates

### DIFF
--- a/custom_components/red_energy/const.py
+++ b/custom_components/red_energy/const.py
@@ -80,6 +80,7 @@ SENSOR_TYPE_CHARGE_CLASS: Final = "charge_class"
 SENSOR_TYPE_STATUS: Final = "status"
 SENSOR_TYPE_ADDRESS: Final = "address"
 SENSOR_TYPE_PAYMENT_TYPE: Final = "payment_type"
+SENSOR_TYPE_RATE_PREFIX: Final = "rate"
 
 # Configuration options
 CONF_SCAN_INTERVAL: Final = "scan_interval"

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -578,6 +578,14 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         
         return service_metadata
 
+    def get_service_rates(self, property_id: str, service_type: str) -> List[Dict[str, Any]]:
+        """Get the validated tariff rates list for a property and service."""
+        metadata = self.get_service_metadata(property_id, service_type)
+        if not metadata:
+            return []
+
+        return metadata.get("rates", [])
+
     def get_latest_import_usage(self, property_id: str, service_type: str) -> Optional[float]:
         """Get the most recent daily import usage."""
         service_data = self.get_service_usage(property_id, service_type)

--- a/custom_components/red_energy/data_validation.py
+++ b/custom_components/red_energy/data_validation.py
@@ -266,7 +266,54 @@ def validate_single_service(data: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(current_plan, dict) and current_plan.get("promotionDesc"):
         validated_service["promotionDesc"] = current_plan["promotionDesc"]
 
+    validated_service["rates"] = validate_rates(
+        current_plan.get("rates") if isinstance(current_plan, dict) else None
+    )
+
     return validated_service
+
+
+def validate_rates(data: Any) -> List[Dict[str, Any]]:
+    """Validate a currentPlan.rates list.
+
+    rateCode is not unique per service - tiered/step rates (e.g. gas Anytime
+    Step1..Step5) repeat the same rateCode and are only distinguished by
+    rateDesc, so both fields are required and preserved as-is.
+    """
+    if not isinstance(data, list):
+        return []
+
+    validated_rates = []
+
+    for rate in data:
+        if not isinstance(rate, dict):
+            continue
+
+        rate_code = rate.get("rateCode")
+        rate_desc = rate.get("rateDesc")
+        if not rate_code or not rate_desc:
+            _LOGGER.warning("Skipping rate entry missing rateCode/rateDesc: %s", rate)
+            continue
+
+        try:
+            rate_incl_gst_cents = float(rate.get("rateInclGstCents", 0))
+        except (ValueError, TypeError) as err:
+            _LOGGER.warning("Skipping rate %s with invalid rateInclGstCents: %s", rate_code, err)
+            continue
+
+        validated_rates.append({
+            "rate_code": str(rate_code),
+            "rate_desc": str(rate_desc),
+            "rate_incl_gst_dollars": round(rate_incl_gst_cents / 100, 5),
+            "type": rate.get("type"),
+            "rate_excl_gst_cents": rate.get("rateExclGstCents"),
+            "discounted_rate_excl_gst_in_cents": rate.get("discountedRateExclGstInCents"),
+            "discounted_rate_incl_gst_in_cents": rate.get("discountedRateInclGstInCents"),
+            "unit": rate.get("unit"),
+            "unit_step_desc": rate.get("unitStepDesc"),
+        })
+
+    return validated_rates
 
 
 def validate_usage_data(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.10.0"
+  "version": "1.11.0"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
+from homeassistant.util import slugify
 
 from .const import (
     CONF_ENABLE_ADVANCED_SENSORS,
@@ -39,6 +40,7 @@ from .const import (
     SENSOR_TYPE_PAYMENT_TYPE,
     SENSOR_TYPE_PEAK_USAGE,
     SENSOR_TYPE_PRODUCT_NAME,
+    SENSOR_TYPE_RATE_PREFIX,
     SENSOR_TYPE_SOLAR,
     SENSOR_TYPE_STATUS,
     SERVICE_TYPE_ELECTRICITY,
@@ -121,6 +123,14 @@ async def async_setup_entry(
                 RedEnergyTotalImportCostSensor(coordinator, config_entry, account_id, service_type),
                 RedEnergyTotalExportCreditSensor(coordinator, config_entry, account_id, service_type),
             ]
+
+            # One diagnostic sensor per contracted tariff rate (peak/off-peak/
+            # supply/demand/etc.) - a dynamic, variable-count set driven by
+            # the plan's actual rates rather than a fixed sensor list.
+            service_entities.extend(
+                RedEnergyRateSensor(coordinator, config_entry, account_id, service_type, rate)
+                for rate in coordinator.get_service_rates(account_id, service_type)
+            )
 
             # Advanced sensors (optional)
             if advanced_sensors_enabled:
@@ -731,6 +741,66 @@ class RedEnergyPaymentTypeSensor(RedEnergyBaseSensor):
             return None
 
         return metadata.get("paymentTypeDescription")
+
+
+class RedEnergyRateSensor(RedEnergyBaseSensor):
+    """Red Energy tariff rate sensor.
+
+    One instance per entry in the plan's rates list. rateCode alone isn't a
+    stable identifier - tiered rates (e.g. gas Anytime Step1..Step5) repeat
+    the same rateCode across steps - so rate_code + rate_desc together key
+    both the unique_id and the coordinator lookup.
+    """
+
+    _requires_usage_data = False
+
+    def __init__(
+        self,
+        coordinator: RedEnergyDataCoordinator,
+        config_entry: ConfigEntry,
+        property_id: str,
+        service_type: str,
+        rate: dict[str, Any],
+    ) -> None:
+        """Initialize the rate sensor."""
+        self._rate_code = rate.get("rate_code", "")
+        self._rate_desc = rate.get("rate_desc", "")
+        slug = slugify(f"{self._rate_code}_{self._rate_desc}")
+
+        super().__init__(
+            coordinator, config_entry, property_id, service_type, f"{SENSOR_TYPE_RATE_PREFIX}_{slug}"
+        )
+
+        self._attr_name = self._rate_desc
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_native_unit_of_measurement = "AUD"
+        self._attr_icon = "mdi:currency-usd"
+
+    def _find_rate(self) -> Optional[dict[str, Any]]:
+        rates = self.coordinator.get_service_rates(self._property_id, self._service_type)
+        return next(
+            (
+                r for r in rates
+                if r.get("rate_code") == self._rate_code and r.get("rate_desc") == self._rate_desc
+            ),
+            None,
+        )
+
+    @property
+    def native_value(self) -> Optional[float]:
+        """Return the rate in dollars, including GST."""
+        rate = self._find_rate()
+        return rate.get("rate_incl_gst_dollars") if rate else None
+
+    @property
+    def extra_state_attributes(self) -> Optional[dict[str, Any]]:
+        """Return the remaining rate fields as attributes."""
+        rate = self._find_rate()
+        if not rate:
+            return None
+
+        return {key: value for key, value in rate.items() if key != "rate_incl_gst_dollars"}
 
 
 class RedEnergyAddressSensor(RedEnergyBaseSensor):

--- a/tests/test_data_validation_errors.py
+++ b/tests/test_data_validation_errors.py
@@ -6,6 +6,7 @@ from custom_components.red_energy.data_validation import (
     validate_address,
     validate_properties_data,
     validate_single_service,
+    validate_rates,
     DataValidationError
 )
 
@@ -392,3 +393,119 @@ def test_validate_single_service_missing_nested_fields_omitted():
     result = validate_single_service(raw_service)
     assert "paymentTypeDescription" not in result
     assert "promotionDesc" not in result
+
+
+def test_validate_single_service_extracts_rates():
+    """currentPlan.rates must surface as a validated list on the service."""
+    raw_service = {
+        "utility": "E",
+        "consumerNumber": "4235478511",
+        "status": "ON",
+        "currentPlan": {
+            "rates": [
+                {
+                    "rateCode": "80008279798P",
+                    "rateDesc": "Peak",
+                    "type": "PR",
+                    "rateExclGstCents": 24.55,
+                    "rateInclGstCents": 27.005,
+                    "discountedRateExclGstInCents": 24.55,
+                    "discountedRateInclGstInCents": 27.005,
+                    "unit": "kWh",
+                    "unitStepDesc": None,
+                },
+            ],
+        },
+    }
+    result = validate_single_service(raw_service)
+    assert len(result["rates"]) == 1
+    rate = result["rates"][0]
+    assert rate["rate_code"] == "80008279798P"
+    assert rate["rate_desc"] == "Peak"
+    assert rate["rate_incl_gst_dollars"] == pytest.approx(0.27005)
+    assert rate["type"] == "PR"
+    assert rate["unit"] == "kWh"
+    assert rate["unit_step_desc"] is None
+
+
+def test_validate_single_service_no_rates_defaults_to_empty_list():
+    """Missing currentPlan/rates must default to an empty list, not KeyError."""
+    raw_service = {
+        "utility": "G",
+        "consumerNumber": "4236257811",
+        "status": "ON",
+    }
+    result = validate_single_service(raw_service)
+    assert result["rates"] == []
+
+
+def test_validate_rates_handles_negative_solar_rate():
+    """Solar feed-in rates are negative (a credit) - must not be rejected."""
+    raw_rates = [
+        {
+            "rateCode": "80008279798GP",
+            "rateDesc": "Solar",
+            "type": "PR",
+            "rateExclGstCents": -3.6364,
+            "rateInclGstCents": -4,
+            "discountedRateExclGstInCents": -3.6364,
+            "discountedRateInclGstInCents": -4,
+            "unit": "kWh",
+            "unitStepDesc": None,
+        },
+    ]
+    result = validate_rates(raw_rates)
+    assert len(result) == 1
+    assert result[0]["rate_incl_gst_dollars"] == pytest.approx(-0.04)
+
+
+def test_validate_rates_handles_duplicate_rate_code_tiered_steps():
+    """Tiered gas rates repeat rateCode across steps - all must be preserved."""
+    raw_rates = [
+        {
+            "rateCode": "10009300825P",
+            "rateDesc": "Anytime Step1",
+            "type": "PSR1",
+            "rateExclGstCents": 4.5,
+            "rateInclGstCents": 4.95,
+            "discountedRateExclGstInCents": 4.5,
+            "discountedRateInclGstInCents": 4.95,
+            "unit": "MJ",
+            "unitStepDesc": "First 20.712 / day",
+        },
+        {
+            "rateCode": "10009300825P",
+            "rateDesc": "Anytime Step2",
+            "type": "PSR1",
+            "rateExclGstCents": 3.3,
+            "rateInclGstCents": 3.63,
+            "discountedRateExclGstInCents": 3.3,
+            "discountedRateInclGstInCents": 3.63,
+            "unit": "MJ",
+            "unitStepDesc": "Next 20.384 / day",
+        },
+    ]
+    result = validate_rates(raw_rates)
+    assert len(result) == 2
+    assert result[0]["rate_code"] == result[1]["rate_code"] == "10009300825P"
+    assert result[0]["rate_desc"] == "Anytime Step1"
+    assert result[1]["rate_desc"] == "Anytime Step2"
+
+
+def test_validate_rates_skips_entries_missing_required_fields():
+    """Entries missing rateCode or rateDesc must be skipped, not raise."""
+    raw_rates = [
+        {"rateDesc": "Missing code", "rateInclGstCents": 1.0},
+        {"rateCode": "X1", "rateInclGstCents": 1.0},
+        {"rateCode": "X2", "rateDesc": "Valid", "rateInclGstCents": 10.0},
+    ]
+    result = validate_rates(raw_rates)
+    assert len(result) == 1
+    assert result[0]["rate_code"] == "X2"
+
+
+def test_validate_rates_handles_non_list_input():
+    """Malformed rates field (not a list) must return an empty list, not raise."""
+    assert validate_rates(None) == []
+    assert validate_rates("not-a-list") == []
+    assert validate_rates({}) == []

--- a/tests/test_sensor_rates.py
+++ b/tests/test_sensor_rates.py
@@ -1,0 +1,226 @@
+"""Test dynamic per-rate diagnostic sensors."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.helpers.entity import EntityCategory
+
+from custom_components.red_energy.const import DOMAIN, SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS
+from custom_components.red_energy.sensor import (
+    RedEnergyRateSensor,
+    async_setup_entry,
+)
+
+ELECTRICITY_RATES = [
+    {
+        "rate_code": "80008279798P",
+        "rate_desc": "Peak",
+        "rate_incl_gst_dollars": 0.27005,
+        "type": "PR",
+        "rate_excl_gst_cents": 24.55,
+        "discounted_rate_excl_gst_in_cents": 24.55,
+        "discounted_rate_incl_gst_in_cents": 27.005,
+        "unit": "kWh",
+        "unit_step_desc": None,
+    },
+    {
+        "rate_code": "80008279798GP",
+        "rate_desc": "Solar",
+        "rate_incl_gst_dollars": -0.04,
+        "type": "PR",
+        "rate_excl_gst_cents": -3.6364,
+        "discounted_rate_excl_gst_in_cents": -3.6364,
+        "discounted_rate_incl_gst_in_cents": -4,
+        "unit": "kWh",
+        "unit_step_desc": None,
+    },
+]
+
+GAS_TIERED_RATES = [
+    {
+        "rate_code": "10009300825P",
+        "rate_desc": "Anytime Step1",
+        "rate_incl_gst_dollars": 0.0495,
+        "type": "PSR1",
+        "rate_excl_gst_cents": 4.5,
+        "discounted_rate_excl_gst_in_cents": 4.5,
+        "discounted_rate_incl_gst_in_cents": 4.95,
+        "unit": "MJ",
+        "unit_step_desc": "First 20.712 / day",
+    },
+    {
+        "rate_code": "10009300825P",
+        "rate_desc": "Anytime Step2",
+        "rate_incl_gst_dollars": 0.0363,
+        "type": "PSR1",
+        "rate_excl_gst_cents": 3.3,
+        "discounted_rate_excl_gst_in_cents": 3.3,
+        "discounted_rate_incl_gst_in_cents": 3.63,
+        "unit": "MJ",
+        "unit_step_desc": "Next 20.384 / day",
+    },
+]
+
+ELECTRICITY_SERVICE_METADATA = {
+    "type": SERVICE_TYPE_ELECTRICITY,
+    "consumer_number": "elec-1",
+    "meterType": "INTERVAL",
+    "solar": True,
+    "rates": ELECTRICITY_RATES,
+}
+
+GAS_SERVICE_METADATA = {
+    "type": SERVICE_TYPE_GAS,
+    "consumer_number": "gas-1",
+    "meterType": "BASIC",
+    "solar": False,
+    "rates": GAS_TIERED_RATES,
+}
+
+
+def _coordinator(service_metadata, service_type, property_id="7471493"):
+    coordinator = MagicMock()
+    coordinator.data = {
+        "usage_data": {
+            property_id: {
+                "property": {
+                    "name": "Test property",
+                    "address": {},
+                    "services": [service_metadata],
+                },
+            },
+        }
+    }
+    coordinator.last_update_success = True
+    coordinator.get_property_data = MagicMock(
+        side_effect=lambda pid: coordinator.data["usage_data"].get(str(pid))
+    )
+
+    def get_service_metadata(prop_id, svc_type):
+        property_data = coordinator.data["usage_data"].get(str(prop_id))
+        if not property_data:
+            return None
+        services = property_data["property"].get("services", [])
+        return next((s for s in services if s.get("type") == svc_type), None)
+
+    coordinator.get_service_metadata = MagicMock(side_effect=get_service_metadata)
+
+    def get_service_rates(prop_id, svc_type):
+        metadata = get_service_metadata(prop_id, svc_type)
+        return metadata.get("rates", []) if metadata else []
+
+    coordinator.get_service_rates = MagicMock(side_effect=get_service_rates)
+    coordinator.get_service_usage = MagicMock(return_value=None)
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_one_rate_sensor_created_per_rate_entry():
+    """async_setup_entry must create one RedEnergyRateSensor per rate in the service."""
+    coordinator = _coordinator(ELECTRICITY_SERVICE_METADATA, SERVICE_TYPE_ELECTRICITY)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["7471493"],
+                "services": [SERVICE_TYPE_ELECTRICITY],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    rate_sensors = [e for e in added_entities if isinstance(e, RedEnergyRateSensor)]
+    assert len(rate_sensors) == 2
+    names = {s._attr_name for s in rate_sensors}
+    assert names == {"Peak", "Solar"}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_rate_code_tiered_gas_rates_produce_distinct_entities():
+    """Tiered gas rates sharing a rateCode must still produce distinct, uniquely-identified entities."""
+    coordinator = _coordinator(GAS_SERVICE_METADATA, SERVICE_TYPE_GAS)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["7471493"],
+                "services": [SERVICE_TYPE_GAS],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    rate_sensors = [e for e in added_entities if isinstance(e, RedEnergyRateSensor)]
+    assert len(rate_sensors) == 2
+    unique_ids = {s.unique_id for s in rate_sensors}
+    assert len(unique_ids) == 2
+    names = {s._attr_name for s in rate_sensors}
+    assert names == {"Anytime Step1", "Anytime Step2"}
+
+
+def test_rate_sensor_native_value_and_attributes():
+    coordinator = _coordinator(ELECTRICITY_SERVICE_METADATA, SERVICE_TYPE_ELECTRICITY)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+
+    sensor = RedEnergyRateSensor(
+        coordinator, config_entry, "7471493", SERVICE_TYPE_ELECTRICITY, ELECTRICITY_RATES[0]
+    )
+
+    assert sensor.native_value == pytest.approx(0.27005)
+    assert sensor._attr_name == "Peak"
+    assert sensor._attr_entity_category == EntityCategory.DIAGNOSTIC
+    assert sensor._attr_device_class.value == "monetary"
+
+    attrs = sensor.extra_state_attributes
+    assert attrs["rate_code"] == "80008279798P"
+    assert attrs["type"] == "PR"
+    assert attrs["unit"] == "kWh"
+    assert "rate_incl_gst_dollars" not in attrs
+
+
+def test_rate_sensor_handles_negative_solar_value():
+    coordinator = _coordinator(ELECTRICITY_SERVICE_METADATA, SERVICE_TYPE_ELECTRICITY)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+
+    sensor = RedEnergyRateSensor(
+        coordinator, config_entry, "7471493", SERVICE_TYPE_ELECTRICITY, ELECTRICITY_RATES[1]
+    )
+
+    assert sensor.native_value == pytest.approx(-0.04)
+
+
+def test_rate_sensor_returns_none_when_rate_no_longer_present():
+    """If the rate disappears from coordinator data (e.g. plan change before reload), native_value is None."""
+    coordinator = _coordinator(ELECTRICITY_SERVICE_METADATA, SERVICE_TYPE_ELECTRICITY)
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+
+    sensor = RedEnergyRateSensor(
+        coordinator, config_entry, "7471493", SERVICE_TYPE_ELECTRICITY,
+        {"rate_code": "gone", "rate_desc": "Gone Rate", "rate_incl_gst_dollars": 1.0},
+    )
+
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes is None


### PR DESCRIPTION
## Summary
- Surfaces each entry in a plan's `currentPlan.rates` (peak/off-peak/shoulder, demand, supply charges, tiered gas steps) as its own diagnostic sensor
- Entity name is `rateDesc`; state is `rateInclGstCents` converted to dollars; remaining fields (type, unit, excl-GST rate, discounted rates, step description) exposed as attributes
- Handles the real-world quirk that `rateCode` repeats across tiered gas rate steps (e.g. gas "Anytime Step1"–"Step5" all share one rateCode) by keying entities on `rate_code` + `rate_desc` together
- v1.10.0 → v1.11.0 (new feature, no breaking changes)

## Commits
- `chore: bump version to 1.11.0` — version bump per branch workflow
- `feat: add diagnostic sensors for tariff rates` — validation, coordinator accessor, and dynamic per-rate sensor wiring

https://claude.ai/code/session_01TwmN1pCWVARTnF28MkrDFP