### PR TITLE
fix: prefix rate sensor names with "Rate "

### DIFF
--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.11.0"
+  "version": "1.11.1"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -771,7 +771,7 @@ class RedEnergyRateSensor(RedEnergyBaseSensor):
             coordinator, config_entry, property_id, service_type, f"{SENSOR_TYPE_RATE_PREFIX}_{slug}"
         )
 
-        self._attr_name = self._rate_desc
+        self._attr_name = f"Rate {self._rate_desc}"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_device_class = SensorDeviceClass.MONETARY
         self._attr_native_unit_of_measurement = "AUD"

--- a/tests/test_sensor_rates.py
+++ b/tests/test_sensor_rates.py
@@ -143,7 +143,7 @@ async def test_one_rate_sensor_created_per_rate_entry():
     rate_sensors = [e for e in added_entities if isinstance(e, RedEnergyRateSensor)]
     assert len(rate_sensors) == 2
     names = {s._attr_name for s in rate_sensors}
-    assert names == {"Peak", "Solar"}
+    assert names == {"Rate Peak", "Rate Solar"}
 
 
 @pytest.mark.asyncio
@@ -175,7 +175,7 @@ async def test_duplicate_rate_code_tiered_gas_rates_produce_distinct_entities():
     unique_ids = {s.unique_id for s in rate_sensors}
     assert len(unique_ids) == 2
     names = {s._attr_name for s in rate_sensors}
-    assert names == {"Anytime Step1", "Anytime Step2"}
+    assert names == {"Rate Anytime Step1", "Rate Anytime Step2"}
 
 
 def test_rate_sensor_native_value_and_attributes():
@@ -188,7 +188,7 @@ def test_rate_sensor_native_value_and_attributes():
     )
 
     assert sensor.native_value == pytest.approx(0.27005)
-    assert sensor._attr_name == "Peak"
+    assert sensor._attr_name == "Rate Peak"
     assert sensor._attr_entity_category == EntityCategory.DIAGNOSTIC
     assert sensor._attr_device_class.value == "monetary"
 


### PR DESCRIPTION
## Summary
- Rate diagnostic sensor names now prefixed with "Rate ", e.g. "Service to Property" becomes "Rate Service to Property"
- v1.11.0 → v1.11.1

https://claude.ai/code/session_01TwmN1pCWVARTnF28MkrDFP