### PR TITLE
chore: bump version to 1.12.0

### DIFF
--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.11.2"
+  "version": "1.12.0"
 }


### PR DESCRIPTION
- Bumps manifest version following the account-number history scrub (all 51 tags, GitHub Releases, and reachable commit history rewritten)
- Marks a clean baseline for future releases