### PR TITLE
fix: dedupe validate workflow runs on PR branches

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,6 +2,8 @@ name: Validate
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.12.1"
+  "version": "1.12.2"
 }


### PR DESCRIPTION
## Summary
- \`validate.yml\`'s \`push\` trigger had no branch filter, so pushing to a PR branch fired both a \`push\` event and a \`pull_request\` event for the same commit, running HACS/hassfest validation twice
- Scopes \`push\` to \`main\` only, matching the pattern already used in \`test.yml\`