### PR TITLE
fix: create a device per property when one account bills several

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,17 @@ The Red Energy API uses non-standard field names:
 | `consumerNumber` | `consumer_number` | camelCase → snake_case |
 | `status: "ON"` | `active: true` | String → bool |
 | `accountNumber` | `id` | Primary property identifier |
+| `propertyNumber` | `property_number` | Per-property key; disambiguates shared account numbers |
 | `suburb` | `city` | Australian terminology |
 | `displayAddresses.shortForm` | `name` | Preferred property display name |
 
 Address fields can be `null` in the API — always use `(data.get("field") or "").strip()` not `data.get("field", "").strip()`.
+
+### Multiple Properties On One Account
+
+`accountNumber` is **not** unique per property — Red Energy bills several properties (different addresses, each with its own consumer) under one account. Since `accountNumber` is the fallback for the property `id`, `validate_properties_data()` rewrites colliding ids to `{accountNumber}_{propertyNumber}` (falling back to the consumer number, then the response index). Only colliding ids are rewritten, so single-property accounts keep the ids their entities are already registered under.
+
+`coordinator._resolve_selected_accounts()` then expands a stored bare account number onto every property derived from it, so entries configured before this existed adopt the extra properties instead of failing to load.
 
 ### Usage Data Structure
 

--- a/custom_components/red_energy/__init__.py
+++ b/custom_components/red_energy/__init__.py
@@ -82,7 +82,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except UpdateFailed as err:
         _LOGGER.error("Failed to set up Red Energy integration: %s", err)
         raise ConfigEntryNotReady(f"Failed to connect to Red Energy: {err}") from err
-    
+
+    # The coordinator resolves the configured selection against the properties
+    # the API actually returned (see _resolve_selected_accounts), which can add
+    # properties billed under an already-selected account. Devices, sensors and
+    # buttons must all be built from that resolved list, not the stale one.
+    selected_accounts = coordinator.selected_accounts
+
     # Set up devices
     devices = await device_manager.async_setup_devices(
         coordinator.data, selected_accounts, services

--- a/custom_components/red_energy/config_flow.py
+++ b/custom_components/red_energy/config_flow.py
@@ -15,7 +15,12 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 
 from .api import RedEnergyAPI, RedEnergyAPIError, RedEnergyAuthError
-from .data_validation import validate_config_data, validate_properties_data, DataValidationError
+from .data_validation import (
+    DataValidationError,
+    format_account_label,
+    validate_config_data,
+    validate_properties_data,
+)
 from .const import (
     CLIENT_ID,
     CONF_ENABLE_ADVANCED_SENSORS,
@@ -177,8 +182,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(user_input[CONF_USERNAME])
                 self._abort_if_unique_id_configured()
                 
-                # Auto-select all accounts - properties are already validated with IDs
-                self._selected_accounts = [account["id"] for account in self._accounts]
+                # Auto-select every property - they are already validated with
+                # ids made unique across the response, so dict.fromkeys() only
+                # guards against an API response repeating a property outright.
+                self._selected_accounts = list(
+                    dict.fromkeys(str(account["id"]) for account in self._accounts)
+                )
                 _LOGGER.info("Auto-selected %d accounts: %s", len(self._selected_accounts), self._selected_accounts)
                 
                 if not self._selected_accounts:
@@ -238,11 +247,10 @@ class RedEnergyOptionsFlowHandler(config_entries.OptionsFlow):
             raw_properties = await coordinator.api.get_properties()
             for account in validate_properties_data(raw_properties):
                 account_id = account["id"]
-                service_label = "/".join(
-                    s.get("type", "").title() for s in account.get("services", []) if s.get("type")
-                )
-                account_options[account_id] = (
-                    f"{account_id} - {service_label}" if service_label else account_id
+                account_options[account_id] = format_account_label(
+                    account_id,
+                    account.get("name"),
+                    [s.get("type") for s in account.get("services", [])],
                 )
         except Exception as err:
             _LOGGER.warning("Could not refresh account list for options flow: %s", err)

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -21,6 +21,7 @@ from .data_validation import (
 from .error_recovery import RedEnergyErrorRecoverySystem, ErrorType
 from .performance import PerformanceMonitor, DataProcessor
 from .const import (
+    DATA_SELECTED_ACCOUNTS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -114,7 +115,8 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
             # Refresh metadata (customer/properties) once per calendar day or on first run
             if self._should_refresh_metadata_today() or not self._customer_data:
                 await self._async_refresh_metadata()
-            
+                self._resolve_selected_accounts()
+
             # Log selected accounts configuration
             _LOGGER.debug("=" * 80)
             _LOGGER.debug("COORDINATOR CONFIGURATION:")
@@ -298,6 +300,59 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
             _LOGGER.exception("Unexpected error during update")
             raise UpdateFailed(f"Unexpected error: {err}") from err
     
+    def _resolve_selected_accounts(self) -> None:
+        """Re-point the selection at properties whose id gained a unique suffix.
+
+        An entry configured before multi-property accounts were disambiguated
+        holds the bare account number. Once that account's properties are split
+        into "{account_number}_{property_number}" ids, nothing matches and the
+        entry fails to load with "No usage data retrieved" - the user would have
+        to delete and re-add the integration to see either property. Expanding
+        the stale id onto every property derived from it adopts them all, which
+        is also what a fresh setup would have done.
+        """
+        available_ids = [str(prop.get("id")) for prop in self._properties]
+        resolved: list[str] = []
+
+        for account_id in self.selected_accounts:
+            account_id = str(account_id)
+            if account_id in available_ids:
+                resolved.append(account_id)
+                continue
+
+            derived_ids = [
+                prop_id
+                for prop_id in available_ids
+                if prop_id.startswith(f"{account_id}_")
+            ]
+            if derived_ids:
+                _LOGGER.info(
+                    "Account %s now bills %d properties - monitoring %s",
+                    account_id, len(derived_ids), derived_ids,
+                )
+                resolved.extend(derived_ids)
+            else:
+                # Unknown to the API right now (transient, or genuinely closed).
+                # Keep it so a temporary API hiccup can't silently drop an
+                # account from the user's configuration.
+                resolved.append(account_id)
+
+        resolved = list(dict.fromkeys(resolved))
+        if resolved == list(self.selected_accounts):
+            return
+
+        _LOGGER.info(
+            "Updating selected accounts from %s to %s",
+            list(self.selected_accounts), resolved,
+        )
+        self.selected_accounts = resolved
+
+        if self.config_entry is not None:
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                data={**self.config_entry.data, DATA_SELECTED_ACCOUNTS: resolved},
+            )
+
     def _should_refresh_metadata_today(self) -> bool:
         """Return True if we haven't refreshed metadata today (calendar day)."""
         today = datetime.now(timezone.utc).date()
@@ -336,6 +391,7 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
     async def async_refresh_metadata_and_usage(self) -> None:
         """Manually trigger metadata refresh and then request full data refresh."""
         await self._async_refresh_metadata()
+        self._resolve_selected_accounts()
         await self.async_request_refresh()
     
     async def _bulk_update_data(self) -> dict[str, Any]:

--- a/custom_components/red_energy/data_validation.py
+++ b/custom_components/red_energy/data_validation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from datetime import datetime
 from typing import Any
 
@@ -69,9 +70,77 @@ def validate_properties_data(data: list[dict[str, Any]]) -> list[dict[str, Any]]
     if not validated_properties:
         _LOGGER.error("No valid properties after validation! Original data: %s", data)
         raise DataValidationError("No valid properties after validation")
-    
+
+    _disambiguate_duplicate_property_ids(validated_properties)
+
     _LOGGER.debug("Successfully validated %d of %d properties", len(validated_properties), len(data))
     return validated_properties
+
+
+def _property_discriminator(property_data: dict[str, Any], index: int) -> str:
+    """Pick a stable per-property suffix for an id shared with another property.
+
+    propertyNumber is the API's own per-property key, so it is preferred. A
+    consumer number is the next-best stable choice (a property's meter), and
+    the response index is a last resort that at least keeps the properties
+    apart within a single update.
+    """
+    property_number = property_data.get("property_number")
+    if property_number:
+        return str(property_number)
+
+    for service in property_data.get("services") or []:
+        consumer_number = service.get("consumer_number")
+        if consumer_number:
+            return str(consumer_number)
+
+    return str(index)
+
+
+def _disambiguate_duplicate_property_ids(properties: list[dict[str, Any]]) -> None:
+    """Make property ids unique when several properties share an account number.
+
+    Red Energy bills multiple properties (different addresses, each with their
+    own consumer) under a single accountNumber, and accountNumber is the
+    fallback used for the property id. Duplicated ids collapse the properties
+    into one coordinator key, one device and one set of sensor unique_ids, so
+    every property but the last silently disappears.
+
+    Only colliding ids are rewritten, so accounts that bill a single property -
+    the overwhelming majority - keep the ids their entities are already
+    registered under.
+    """
+    id_counts = Counter(prop["id"] for prop in properties)
+    duplicated_ids = {prop_id for prop_id, count in id_counts.items() if count > 1}
+
+    if not duplicated_ids:
+        return
+
+    _LOGGER.info(
+        "Account number(s) %s bill more than one property - deriving unique "
+        "property ids so each gets its own device",
+        ", ".join(sorted(duplicated_ids)),
+    )
+
+    assigned_ids = {prop["id"] for prop in properties} - duplicated_ids
+
+    for index, prop in enumerate(properties):
+        original_id = prop["id"]
+        if original_id not in duplicated_ids:
+            continue
+
+        new_id = f"{original_id}_{_property_discriminator(prop, index)}"
+        # A discriminator can only repeat if the API returns the same property
+        # twice; fall back to the index so no property is dropped.
+        if new_id in assigned_ids:
+            new_id = f"{original_id}_{index}"
+
+        assigned_ids.add(new_id)
+        prop["id"] = new_id
+        _LOGGER.debug(
+            "Property '%s' on account %s assigned unique id %s",
+            prop.get("name"), original_id, new_id,
+        )
 
 
 def validate_single_property(data: dict[str, Any]) -> dict[str, Any]:
@@ -137,7 +206,18 @@ def validate_single_property(data: dict[str, Any]) -> dict[str, Any]:
         "address": validate_address(data.get("address", {})),
         "services": validate_services(services_data),
     }
-    
+
+    # Kept alongside the id so validate_properties_data() can tell apart
+    # several properties billed under one account number - the id itself falls
+    # back to accountNumber, which is shared in that case.
+    property_number = data.get("propertyNumber") or data.get("property_number")
+    if property_number is not None:
+        validated_property["property_number"] = str(property_number)
+
+    account_number = data.get("accountNumber") or data.get("account_number")
+    if account_number is not None:
+        validated_property["account_number"] = str(account_number)
+
     _LOGGER.debug("Validated property: %s (ID: %s) with %d services", 
                 validated_property["name"], validated_property["id"], len(validated_property["services"]))
     return validated_property
@@ -483,6 +563,33 @@ def validate_usage_entry(data: dict[str, Any]) -> dict[str, Any]:
     validated_data.pop("_breakdown_available", None)
     
     return validated_data
+
+
+def format_account_label(
+    account_id: str, name: str | None, service_types: list[str]
+) -> str:
+    """Build a human-readable label for a property/account.
+
+    Both discriminators are needed: one account can bill several properties at
+    different addresses (so the id alone repeats a service type), and one
+    address can be split across separate electricity and gas accounts (so the
+    address alone repeats). Used for device names and the options-flow account
+    checklist so the two always match.
+    """
+    account_id = str(account_id)
+    parts = [account_id]
+
+    name = str(name or "").strip()
+    if name and name not in (account_id, f"Property {account_id}"):
+        parts.append(name)
+
+    service_label = "/".join(
+        service_type.title() for service_type in service_types if service_type
+    )
+    if service_label:
+        parts.append(service_label)
+
+    return " - ".join(parts)
 
 
 def sanitize_sensor_name(name: str) -> str:

--- a/custom_components/red_energy/device_manager.py
+++ b/custom_components/red_energy/device_manager.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN, MANUFACTURER, SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS
+from .data_validation import format_account_label
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -56,15 +57,17 @@ class RedEnergyDeviceManager:
         services: list[str]
     ) -> DeviceEntry | None:
         """Create or update a device for a property."""
-        # Red Energy can split a single address across multiple accounts
-        # (e.g. electricity and gas billed separately), so the account's own
-        # service type(s) - not the global services toggle - must drive the
-        # device name/model to keep devices distinguishable per account.
+        # Red Energy can split a single address across multiple accounts (e.g.
+        # electricity and gas billed separately) and can also bill several
+        # addresses under one account, so the device name carries the account's
+        # own service type(s) and its address - not the global services toggle -
+        # to keep every device distinguishable.
         account_services = [
             s.get("type") for s in property_info.get("services", []) if s.get("type")
         ] or services
-        service_label = "/".join(s.title() for s in account_services)
-        device_name = f"{account_id} - {service_label}" if service_label else str(account_id)
+        device_name = format_account_label(
+            account_id, property_info.get("name"), account_services
+        )
         address = property_info.get("address", {})
 
         # Create comprehensive device identifiers

--- a/tests/test_config_flow_options_accounts.py
+++ b/tests/test_config_flow_options_accounts.py
@@ -86,7 +86,9 @@ async def test_options_account_labels_use_account_id_not_shared_address():
     Both mock properties share the display address "27 Sunnyside Crescent,
     Castlecrag" (electricity and gas billed on separate accounts) - the
     label shown to the user must not be that address for both, or the
-    options screen is unusable (matches the reported UI screenshot).
+    options screen is unusable (matches the reported UI screenshot). The
+    address still appears alongside the id and service, since one account can
+    bill several addresses and the id alone then means nothing to the user.
     """
     entry = _make_config_entry()
     hass = _make_hass(entry)
@@ -102,8 +104,8 @@ async def test_options_account_labels_use_account_id_not_shared_address():
     )
     labels = accounts_validator.options
 
-    assert labels["1000001"] == "1000001 - Electricity"
-    assert labels["2000002"] == "2000002 - Gas"
+    assert labels["1000001"] == "1000001 - 27 Sunnyside Crescent, Castlecrag - Electricity"
+    assert labels["2000002"] == "2000002 - 27 Sunnyside Crescent, Castlecrag - Gas"
     assert "27 Sunnyside Crescent, Castlecrag" not in labels.values()
 
 

--- a/tests/test_device_manager_split_accounts.py
+++ b/tests/test_device_manager_split_accounts.py
@@ -56,8 +56,36 @@ async def test_split_accounts_at_same_address_get_distinct_device_names():
     )
 
     assert electricity_device.name != gas_device.name
-    assert electricity_device.name == "1000001 - Electricity"
-    assert gas_device.name == "2000002 - Gas"
+    assert (
+        electricity_device.name
+        == "1000001 - 27 Sunnyside Crescent, Castlecrag - Electricity"
+    )
+    assert gas_device.name == "2000002 - 27 Sunnyside Crescent, Castlecrag - Gas"
+
+
+@pytest.mark.asyncio
+async def test_properties_on_one_account_get_distinct_device_names():
+    """Two addresses billed under one account must not produce identical devices.
+
+    Their ids differ only by a suffix, so the address is what actually tells
+    the two devices apart in the UI.
+    """
+    manager = _make_device_manager()
+
+    first_device = await manager._create_property_device(
+        "1001100_5000001",
+        _property_info("1 First St, Suburbia", SERVICE_TYPE_ELECTRICITY),
+        [SERVICE_TYPE_ELECTRICITY],
+    )
+    second_device = await manager._create_property_device(
+        "1001100_5000002",
+        _property_info("2 Second Ave, Othertown", SERVICE_TYPE_ELECTRICITY),
+        [SERVICE_TYPE_ELECTRICITY],
+    )
+
+    assert first_device.name != second_device.name
+    assert first_device.name == "1001100_5000001 - 1 First St, Suburbia - Electricity"
+    assert second_device.name == "1001100_5000002 - 2 Second Ave, Othertown - Electricity"
 
 
 @pytest.mark.asyncio

--- a/tests/test_multi_property_accounts.py
+++ b/tests/test_multi_property_accounts.py
@@ -1,0 +1,251 @@
+"""Test accounts that bill more than one property.
+
+Red Energy can bill several properties (different addresses, each with their
+own consumer/meter) under a single accountNumber. accountNumber is the fallback
+used for the property id, so without disambiguation every such property
+collapses into one coordinator key, one device and one set of sensor
+unique_ids - the user sees a single device and a single account to monitor no
+matter how many services they actually have.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.red_energy.config_flow import (
+    ConfigFlow,
+    RedEnergyOptionsFlowHandler,
+)
+from custom_components.red_energy.const import (
+    DATA_ACCOUNTS,
+    DATA_CUSTOMER_DATA,
+    DATA_SELECTED_ACCOUNTS,
+    DOMAIN,
+    SERVICE_TYPE_ELECTRICITY,
+)
+from custom_components.red_energy.coordinator import RedEnergyDataCoordinator
+from custom_components.red_energy.data_validation import (
+    format_account_label,
+    validate_properties_data,
+)
+
+SHARED_ACCOUNT_NUMBER = 1001100
+
+
+def _raw_property(account_number, property_number, consumer_number, short_form):
+    """Build a raw /properties entry in the shape the API returns."""
+    raw = {
+        "accountNumber": account_number,
+        "address": {
+            "house": "1",
+            "street": "SOME ST",
+            "suburb": short_form.split(", ")[-1].upper(),
+            "state": "NSW",
+            "postcode": "2000",
+            "displayAddresses": {"shortForm": short_form},
+        },
+        "consumers": [
+            {
+                "consumerNumber": consumer_number,
+                "utility": "E",
+                "status": "ON",
+            }
+        ],
+    }
+    if property_number is not None:
+        raw["propertyNumber"] = property_number
+    return raw
+
+
+MULTI_PROPERTY_RESPONSE = [
+    _raw_property(SHARED_ACCOUNT_NUMBER, 5000001, 3000003, "1 First St, Suburbia"),
+    _raw_property(SHARED_ACCOUNT_NUMBER, 5000002, 3000004, "2 Second Ave, Othertown"),
+]
+
+
+def test_properties_sharing_an_account_number_get_unique_ids():
+    """Two properties on one account must not collapse into a single id."""
+    properties = validate_properties_data(MULTI_PROPERTY_RESPONSE)
+
+    ids = [prop["id"] for prop in properties]
+    assert len(properties) == 2
+    assert len(set(ids)) == 2, f"ids collided: {ids}"
+    assert ids == ["1001100_5000001", "1001100_5000002"]
+
+
+def test_duplicate_ids_fall_back_to_consumer_number():
+    """Without propertyNumber the consumer number keeps the properties apart."""
+    raw = [
+        _raw_property(SHARED_ACCOUNT_NUMBER, None, 3000003, "1 First St, Suburbia"),
+        _raw_property(SHARED_ACCOUNT_NUMBER, None, 3000004, "2 Second Ave, Othertown"),
+    ]
+
+    ids = [prop["id"] for prop in validate_properties_data(raw)]
+
+    assert ids == ["1001100_3000003", "1001100_3000004"]
+
+
+def test_distinct_account_numbers_keep_their_existing_ids():
+    """Only colliding ids are rewritten - existing entities must not churn.
+
+    A suffix applied unconditionally would change the unique_id of every
+    already-registered sensor, orphaning their history.
+    """
+    raw = [
+        _raw_property(1000001, 5000001, 3000003, "27 Sunnyside Crescent, Castlecrag"),
+        _raw_property(2000002, 5000002, 4000004, "9 Other Road, Elsewhere"),
+    ]
+
+    ids = [prop["id"] for prop in validate_properties_data(raw)]
+
+    assert ids == ["1000001", "2000002"]
+
+
+def test_property_and_account_numbers_are_preserved():
+    """Both raw identifiers stay available for disambiguation and diagnostics."""
+    prop = validate_properties_data(MULTI_PROPERTY_RESPONSE)[0]
+
+    assert prop["property_number"] == "5000001"
+    assert prop["account_number"] == "1001100"
+
+
+def test_account_label_distinguishes_properties_on_one_account():
+    """Labels for a shared account must differ - the address is the only clue."""
+    properties = validate_properties_data(MULTI_PROPERTY_RESPONSE)
+
+    labels = [
+        format_account_label(
+            prop["id"], prop["name"], [s["type"] for s in prop["services"]]
+        )
+        for prop in properties
+    ]
+
+    assert labels == [
+        "1001100_5000001 - 1 First St, Suburbia - Electricity",
+        "1001100_5000002 - 2 Second Ave, Othertown - Electricity",
+    ]
+
+
+def test_account_label_omits_a_name_that_only_repeats_the_id():
+    """The synthetic "Property <id>" fallback name adds nothing to the label."""
+    assert (
+        format_account_label("1000001", "Property 1000001", ["electricity"])
+        == "1000001 - Electricity"
+    )
+
+
+@pytest.mark.asyncio
+async def test_config_flow_selects_every_property_on_a_shared_account(monkeypatch):
+    """Initial setup must adopt both properties, not just one."""
+    properties = validate_properties_data(MULTI_PROPERTY_RESPONSE)
+
+    async def fake_validate_input(hass, data):
+        return {
+            DATA_CUSTOMER_DATA: {"name": "Test Customer"},
+            DATA_ACCOUNTS: properties,
+            "title": "Test Customer",
+        }
+
+    monkeypatch.setattr(
+        "custom_components.red_energy.config_flow.validate_input", fake_validate_input
+    )
+
+    flow = ConfigFlow()
+    flow.hass = MagicMock()
+    flow.async_set_unique_id = AsyncMock()
+    flow._abort_if_unique_id_configured = AsyncMock()
+    flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
+
+    await flow.async_step_user({"username": "test@example.com", "password": "testpass"})
+
+    flow.async_create_entry.assert_called_once()
+    _, kwargs = flow.async_create_entry.call_args
+    assert kwargs["data"][DATA_SELECTED_ACCOUNTS] == [
+        "1001100_5000001",
+        "1001100_5000002",
+    ]
+    assert "2 properties" in kwargs["title"]
+
+
+@pytest.mark.asyncio
+async def test_options_flow_lists_every_property_on_a_shared_account():
+    """The options checklist must offer both properties with distinct labels."""
+    entry = MagicMock()
+    entry.data = {
+        "username": "test@example.com",
+        "password": "testpass",
+        DATA_SELECTED_ACCOUNTS: ["1001100_5000001", "1001100_5000002"],
+        "services": [SERVICE_TYPE_ELECTRICITY],
+    }
+    entry.options = {}
+    entry.entry_id = "test_entry_id"
+
+    coordinator = MagicMock(update_interval=MagicMock(total_seconds=lambda: 1800))
+    coordinator.api.get_properties = AsyncMock(return_value=MULTI_PROPERTY_RESPONSE)
+    hass = MagicMock()
+    hass.data = {DOMAIN: {entry.entry_id: {"coordinator": coordinator}}}
+    hass.config_entries.async_get_known_entry = MagicMock(return_value=entry)
+
+    flow = RedEnergyOptionsFlowHandler()
+    flow.hass = hass
+    flow.handler = entry.entry_id
+
+    result = await flow.async_step_init()
+
+    accounts_validator = next(
+        v for k, v in result["data_schema"].schema.items() if str(k) == "accounts"
+    )
+    labels = accounts_validator.options
+
+    assert set(labels) == {"1001100_5000001", "1001100_5000002"}
+    assert len(set(labels.values())) == 2
+
+
+def _make_coordinator(selected_accounts, config_entry=None):
+    hass = MagicMock()
+    coordinator = RedEnergyDataCoordinator.__new__(RedEnergyDataCoordinator)
+    coordinator.hass = hass
+    coordinator.selected_accounts = selected_accounts
+    coordinator.config_entry = config_entry
+    coordinator._properties = validate_properties_data(MULTI_PROPERTY_RESPONSE)
+    return coordinator
+
+
+def test_coordinator_expands_a_legacy_bare_account_id():
+    """An entry saved before disambiguation must adopt the derived properties.
+
+    Its stored selection is the bare account number, which now matches no
+    property id at all - left alone the entry fails to load with "No usage data
+    retrieved" and the user has to delete and re-add the integration.
+    """
+    entry = MagicMock()
+    entry.data = {DATA_SELECTED_ACCOUNTS: ["1001100"]}
+    coordinator = _make_coordinator(["1001100"], config_entry=entry)
+
+    coordinator._resolve_selected_accounts()
+
+    assert coordinator.selected_accounts == ["1001100_5000001", "1001100_5000002"]
+    _, kwargs = coordinator.hass.config_entries.async_update_entry.call_args
+    assert kwargs["data"][DATA_SELECTED_ACCOUNTS] == [
+        "1001100_5000001",
+        "1001100_5000002",
+    ]
+
+
+def test_coordinator_leaves_a_matching_selection_alone():
+    """A selection that already matches must not be rewritten or re-persisted."""
+    coordinator = _make_coordinator(["1001100_5000001", "1001100_5000002"])
+
+    coordinator._resolve_selected_accounts()
+
+    assert coordinator.selected_accounts == ["1001100_5000001", "1001100_5000002"]
+    coordinator.hass.config_entries.async_update_entry.assert_not_called()
+
+
+def test_coordinator_keeps_an_account_the_api_did_not_return():
+    """A transient API omission must not silently drop the user's selection."""
+    coordinator = _make_coordinator(["1001100_5000001", "9999999"])
+
+    coordinator._resolve_selected_accounts()
+
+    assert "9999999" in coordinator.selected_accounts


### PR DESCRIPTION
Red Energy bills multiple properties (different addresses, each with its own consumer/meter) under a single accountNumber. accountNumber is the fallback used for the property id, so every such property collapsed into one coordinator key, one device and one set of sensor unique_ids - the user saw a single device and a single "account to monitor" no matter how many services they actually had.

validate_properties_data() now rewrites colliding ids to "{accountNumber}_{propertyNumber}", falling back to the consumer number and then the response index. Only colliding ids are rewritten, so single-property accounts keep the ids their entities are already registered under and no history is orphaned.

An entry configured before this stores the bare account number, which now matches no property at all and would fail to load with "No usage data retrieved". The coordinator expands such a selection onto every property derived from it, adopting them all as a fresh setup would.

Device names and options-flow labels now carry the address alongside the id and service type, since ids that differ only by suffix tell the user nothing about which property is which.

This Fixes https://github.com/craibo/ha-red-energy-au/issues/51