### PR TITLE
fix: keep properties distinct when accountNumber is shared

### DIFF
--- a/custom_components/red_energy/config_migration.py
+++ b/custom_components/red_energy/config_migration.py
@@ -32,7 +32,8 @@ CONFIG_VERSION_4 = 4  # Auto-select all accounts and fix account ID matching
 CONFIG_VERSION_5 = 5  # Fixed device identifier mismatch (removed duplicate devices)
 CONFIG_VERSION_6 = 6  # Removed client_id from user config (now hardcoded)
 CONFIG_VERSION_7 = 7  # Removed service-type selection (always monitor both)
-CURRENT_CONFIG_VERSION = CONFIG_VERSION_7
+CONFIG_VERSION_8 = 8  # Composite property IDs (fix accounts with shared accountNumber)
+CURRENT_CONFIG_VERSION = CONFIG_VERSION_8
 
 
 class ConfigValidationError(Exception):
@@ -85,6 +86,10 @@ class RedEnergyConfigMigrator:
             # Migrate from version 6 to 7
             if current_version < CONFIG_VERSION_7:
                 migration_success &= await self._migrate_v6_to_v7(config_entry)
+
+            # Migrate from version 7 to 8
+            if current_version < CONFIG_VERSION_8:
+                migration_success &= await self._migrate_v7_to_v8(config_entry)
 
             if migration_success:
                 # Update version in config entry
@@ -332,6 +337,112 @@ class RedEnergyConfigMigrator:
         except Exception as err:
             _LOGGER.error("Failed to migrate v6 to v7: %s", err, exc_info=True)
             return False
+
+    async def _migrate_v7_to_v8(self, config_entry: ConfigEntry) -> bool:
+        """Migrate from version 7 to 8 - Composite property IDs.
+
+        Red Energy can group multiple physical properties under one billing
+        account, so they share the same accountNumber. Property IDs used to
+        be derived from accountNumber alone, which silently collapsed those
+        properties into a single device/entity set (see GitHub issue #51).
+        IDs are now composed from propertyPhysicalNumber + accountNumber,
+        which is unique per property.
+
+        For every property whose ID changes, the existing device and its
+        entities are renamed in place (rather than deleted/recreated) so
+        entity history and Energy Dashboard statistics carry over.
+        """
+        _LOGGER.info("Migrating config entry from v7 to v8 - Updating property IDs")
+
+        try:
+            from homeassistant.helpers.aiohttp_client import async_get_clientsession
+            from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+            from .api import RedEnergyAPI
+            from .data_validation import validate_properties_data
+
+            new_data = dict(config_entry.data)
+            selected_accounts = new_data.get(DATA_SELECTED_ACCOUNTS, [])
+
+            session = async_get_clientsession(self.hass)
+            api = RedEnergyAPI(session)
+
+            try:
+                await api.authenticate(new_data[CONF_USERNAME], new_data[CONF_PASSWORD])
+                raw_properties = await api.get_properties()
+            except Exception as err:
+                _LOGGER.warning(
+                    "Could not refresh properties during v7 to v8 migration (%s) - "
+                    "existing IDs will be kept and re-evaluated on next successful setup",
+                    err,
+                )
+                return True
+
+            # Old IDs were accountNumber alone, so recompute what each fetched
+            # property's old-style ID would have been to match it against the
+            # previously selected accounts.
+            id_map: dict[str, str] = {}
+            for raw_property in raw_properties:
+                account_number = raw_property.get("accountNumber")
+                if not account_number:
+                    continue
+                old_id = str(account_number)
+                if old_id in selected_accounts and old_id not in id_map:
+                    new_id = validate_properties_data([raw_property])[0]["id"]
+                    if new_id != old_id:
+                        id_map[old_id] = new_id
+
+            if not id_map:
+                _LOGGER.debug("No property IDs changed format, nothing to migrate")
+                return True
+
+            new_data[DATA_SELECTED_ACCOUNTS] = [
+                id_map.get(account_id, account_id) for account_id in selected_accounts
+            ]
+
+            device_registry = dr.async_get(self.hass)
+            entity_registry = er.async_get(self.hass)
+
+            for old_id, new_id in id_map.items():
+                device = device_registry.async_get_device(identifiers={(DOMAIN, old_id)})
+                if not device:
+                    continue
+
+                for entity in er.async_entries_for_device(
+                    entity_registry, device.id, include_disabled_entities=True
+                ):
+                    old_segment = f"_{old_id}_"
+                    if old_segment not in entity.unique_id:
+                        continue
+                    new_unique_id = entity.unique_id.replace(old_segment, f"_{new_id}_")
+                    if new_unique_id != entity.unique_id:
+                        entity_registry.async_update_entity(
+                            entity.entity_id, new_unique_id=new_unique_id
+                        )
+                        _LOGGER.info(
+                            "Migrated entity %s unique_id from %s to %s",
+                            entity.entity_id, entity.unique_id, new_unique_id
+                        )
+
+                device_registry.async_update_device(
+                    device.id, new_identifiers={(DOMAIN, new_id)}
+                )
+                _LOGGER.info("Migrated device %s identifier from %s to %s", device.name, old_id, new_id)
+
+            self.hass.config_entries.async_update_entry(config_entry, data=new_data)
+
+            _LOGGER.info(
+                "Successfully migrated to v8, updated %d property ID(s): %s",
+                len(id_map), id_map
+            )
+
+            return True
+
+        except Exception as err:
+            _LOGGER.error("Failed to migrate v7 to v8: %s", err, exc_info=True)
+            # Don't fail the entire migration - the fix still applies for new
+            # device/entity creation, existing ones just won't be renamed.
+            return True
 
 
 class RedEnergyConfigValidator:

--- a/custom_components/red_energy/data_validation.py
+++ b/custom_components/red_energy/data_validation.py
@@ -80,9 +80,23 @@ def validate_single_property(data: dict[str, Any]) -> dict[str, Any]:
         raise DataValidationError("Property data must be a dictionary")
     
     _LOGGER.debug("Validating property with keys: %s", list(data.keys()))
-    
-    property_id = data.get("id") or data.get("propertyId") or data.get("property_id") or data.get("accountNumber")
-    
+
+    # accountNumber is not always unique per property - Red Energy can group
+    # multiple physical properties under one billing account, in which case
+    # they all share the same accountNumber. propertyPhysicalNumber is unique
+    # per property, so prefer propertyNumber (or a composed equivalent) to
+    # avoid collapsing distinct properties into a single id downstream.
+    property_physical_number = data.get("propertyPhysicalNumber")
+    account_number = data.get("accountNumber")
+    property_id = (
+        data.get("id")
+        or data.get("propertyId")
+        or data.get("property_id")
+        or data.get("propertyNumber")
+        or (f"{property_physical_number}.{account_number}" if property_physical_number and account_number else None)
+        or account_number
+    )
+
     if not property_id:
         address = data.get("address", {})
         if isinstance(address, dict):

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.12.2"
+  "version": "1.13.0"
 }

--- a/tests/test_config_migration_v7.py
+++ b/tests/test_config_migration_v7.py
@@ -59,5 +59,5 @@ async def test_current_version_entry_not_migrated():
     hass.config_entries.async_update_entry.assert_not_called()
 
 
-def test_config_version_7_is_current():
-    assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_7
+def test_config_version_7_exists():
+    assert CONFIG_VERSION_7 == 7

--- a/tests/test_config_migration_v8.py
+++ b/tests/test_config_migration_v8.py
@@ -1,0 +1,167 @@
+"""Test config migration to v8 - composite property IDs.
+
+Regression test for GitHub issue #51: properties sharing accountNumber used
+to collapse into a single device/entity set. v8 switches to a composite ID
+(propertyPhysicalNumber + accountNumber) and migrates existing devices and
+entities in place so history/statistics are preserved.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.red_energy.config_migration import (
+    CONFIG_VERSION_8,
+    CURRENT_CONFIG_VERSION,
+    RedEnergyConfigMigrator,
+)
+from custom_components.red_energy.const import DOMAIN
+
+
+def _make_config_entry(selected_accounts):
+    entry = MagicMock()
+    entry.version = 7
+    entry.entry_id = "entry1"
+    entry.data = {
+        "username": "test@example.com",
+        "password": "testpass",
+        "selected_accounts": selected_accounts,
+        "services": ["electricity", "gas"],
+    }
+    return entry
+
+
+def _raw_properties():
+    return [
+        {
+            "accountNumber": 1001100,
+            "propertyPhysicalNumber": 1111111,
+            "address": {"street": "1 FIRST STREET", "suburb": "SUBURBIA"},
+            "consumers": [{"consumerNumber": 2000001, "utility": "E", "status": "ON"}],
+        },
+        {
+            "accountNumber": 1001100,
+            "propertyPhysicalNumber": 2222222,
+            "address": {"street": "2 SECOND STREET", "suburb": "SUBURBIA"},
+            "consumers": [{"consumerNumber": 2000002, "utility": "E", "status": "ON"}],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_v7_entry_with_collapsed_account_id_gets_composite_ids():
+    """The one property previously selected under the shared accountNumber
+    is remapped to its new composite ID."""
+    entry = _make_config_entry(selected_accounts=["1001100"])
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    mock_device = MagicMock()
+    mock_device.id = "device1"
+    mock_device.name = "1001100 - Electricity"
+
+    mock_entity = MagicMock()
+    mock_entity.entity_id = "sensor.red_energy_1001100_daily_import_usage"
+    mock_entity.unique_id = f"{DOMAIN}_entry1_1001100_electricity_daily_import_usage"
+
+    with patch(
+        "custom_components.red_energy.api.RedEnergyAPI.authenticate",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "custom_components.red_energy.api.RedEnergyAPI.get_properties",
+        new=AsyncMock(return_value=_raw_properties()),
+    ), patch(
+        "homeassistant.helpers.aiohttp_client.async_get_clientsession",
+        return_value=MagicMock(),
+    ), patch(
+        "homeassistant.helpers.device_registry.async_get"
+    ) as mock_dr_get, patch(
+        "homeassistant.helpers.entity_registry.async_get"
+    ) as mock_er_get, patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_device",
+        return_value=[mock_entity],
+    ):
+        mock_device_registry = MagicMock()
+        mock_device_registry.async_get_device.return_value = mock_device
+        mock_dr_get.return_value = mock_device_registry
+
+        mock_entity_registry = MagicMock()
+        mock_er_get.return_value = mock_entity_registry
+
+        migrator = RedEnergyConfigMigrator(hass)
+        result = await migrator._migrate_v7_to_v8(entry)
+
+    assert result is True
+
+    # Only one of the two properties was previously selected/visible, so only
+    # that one is remapped - the newly-discovered sibling property is left
+    # for the user to add via the options flow, with no history to preserve.
+    mock_entity_registry.async_update_entity.assert_called_once_with(
+        mock_entity.entity_id, new_unique_id=f"{DOMAIN}_entry1_1111111.1001100_electricity_daily_import_usage"
+    )
+    mock_device_registry.async_update_device.assert_called_once_with(
+        mock_device.id, new_identifiers={(DOMAIN, "1111111.1001100")}
+    )
+
+    new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+    assert new_data["selected_accounts"] == ["1111111.1001100"]
+
+
+@pytest.mark.asyncio
+async def test_v7_entry_with_already_unique_ids_is_a_noop():
+    """Properties that already had distinct accountNumbers keep their IDs."""
+    entry = _make_config_entry(selected_accounts=["1000001"])
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    raw_properties = [
+        {
+            "accountNumber": 1000001,
+            "address": {"street": "1 FIRST STREET", "suburb": "SUBURBIA"},
+            "consumers": [{"consumerNumber": 2000001, "utility": "E", "status": "ON"}],
+        }
+    ]
+
+    with patch(
+        "custom_components.red_energy.api.RedEnergyAPI.authenticate",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "custom_components.red_energy.api.RedEnergyAPI.get_properties",
+        new=AsyncMock(return_value=raw_properties),
+    ), patch(
+        "homeassistant.helpers.aiohttp_client.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        migrator = RedEnergyConfigMigrator(hass)
+        result = await migrator._migrate_v7_to_v8(entry)
+
+    assert result is True
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_v7_to_v8_api_failure_does_not_fail_migration():
+    """If the API can't be reached during migration, existing config is kept
+    and the fix still applies going forward for new setups."""
+    entry = _make_config_entry(selected_accounts=["1001100"])
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    with patch(
+        "custom_components.red_energy.api.RedEnergyAPI.authenticate",
+        new=AsyncMock(side_effect=Exception("network error")),
+    ), patch(
+        "homeassistant.helpers.aiohttp_client.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        migrator = RedEnergyConfigMigrator(hass)
+        result = await migrator._migrate_v7_to_v8(entry)
+
+    assert result is True
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+def test_config_version_8_is_current():
+    assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_8
+    assert CONFIG_VERSION_8 == 8

--- a/tests/test_data_validation_errors.py
+++ b/tests/test_data_validation_errors.py
@@ -353,6 +353,52 @@ def test_validate_properties_data_handles_address_with_none_house():
     assert result[0]["address"]["postcode"] == "2068"
 
 
+def test_validate_properties_data_shared_account_number_stays_distinct():
+    """Two properties on one billing account share accountNumber but must
+    still validate to distinct IDs (see GitHub issue #51)."""
+    raw_properties = [
+        {
+            "accountNumber": 1001100,
+            "propertyPhysicalNumber": 1111111,
+            "address": {
+                "street": "1 FIRST STREET",
+                "suburb": "SUBURBIA",
+                "state": "NSW",
+                "postcode": "2000",
+            },
+            "consumers": [
+                {
+                    "consumerNumber": 2000001,
+                    "utility": "E",
+                    "status": "ON",
+                }
+            ],
+        },
+        {
+            "accountNumber": 1001100,
+            "propertyPhysicalNumber": 2222222,
+            "address": {
+                "street": "2 SECOND STREET",
+                "suburb": "SUBURBIA",
+                "state": "NSW",
+                "postcode": "2000",
+            },
+            "consumers": [
+                {
+                    "consumerNumber": 2000002,
+                    "utility": "E",
+                    "status": "ON",
+                }
+            ],
+        },
+    ]
+    result = validate_properties_data(raw_properties)
+    assert len(result) == 2
+    ids = {prop["id"] for prop in result}
+    assert len(ids) == 2
+    assert ids == {"1111111.1001100", "2222222.1001100"}
+
+
 def test_validate_single_service_extracts_payment_type_description():
     """paymentTypeDetail.paymentTypeDescription must surface as a flat field."""
     raw_service = {

--- a/tests/test_device_identifier_fix.py
+++ b/tests/test_device_identifier_fix.py
@@ -168,10 +168,10 @@ def test_device_model_dual_service():
 
 
 def test_migration_version():
-    """Test that migration version is set to 7."""
-    from custom_components.red_energy.config_migration import CURRENT_CONFIG_VERSION, CONFIG_VERSION_5, CONFIG_VERSION_7
+    """Test that migration version 5 (device identifier fix) still exists."""
+    from custom_components.red_energy.config_migration import CURRENT_CONFIG_VERSION, CONFIG_VERSION_5
 
-    assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_7
+    assert CURRENT_CONFIG_VERSION >= CONFIG_VERSION_5
     assert CONFIG_VERSION_5 == 5
 
     print(f"✓ Current config version: {CURRENT_CONFIG_VERSION}")


### PR DESCRIPTION
Fixes #51

- Properties on the same billing account (shared `accountNumber`) were collapsing into a single device/entity set, since the property `id` was derived from `accountNumber` alone with nothing to disambiguate
- `id` now composes `propertyPhysicalNumber` with `accountNumber` when both are present, falling back to the previous chain otherwise
- Added a v7→v8 config migration that renames existing devices and entities in place (rather than delete/recreate), so history and Energy Dashboard statistics carry over for affected accounts
- Migration degrades gracefully if the API is unreachable during upgrade — existing config is kept and the fix still applies for new setups

## Commits
- `chore: bump version to 1.13.0` — version bump per branch workflow
- `fix: keep properties distinct when accountNumber is shared` — the id derivation fix, migration, and regression tests