### PR TITLE
fix: correct old-ID detection in v7->v8 migration

### DIFF
--- a/custom_components/red_energy/config_migration.py
+++ b/custom_components/red_energy/config_migration.py
@@ -378,15 +378,22 @@ class RedEnergyConfigMigrator:
                 )
                 return True
 
-            # Old IDs were accountNumber alone, so recompute what each fetched
-            # property's old-style ID would have been to match it against the
-            # previously selected accounts.
+            # Recompute what each fetched property's OLD-style ID would have
+            # been (pre-v8 fallback chain: id -> propertyId -> property_id ->
+            # accountNumber) so it can be matched against the previously
+            # selected accounts, regardless of which field actually produced
+            # that account's old ID.
             id_map: dict[str, str] = {}
             for raw_property in raw_properties:
-                account_number = raw_property.get("accountNumber")
-                if not account_number:
+                old_id = (
+                    raw_property.get("id")
+                    or raw_property.get("propertyId")
+                    or raw_property.get("property_id")
+                    or raw_property.get("accountNumber")
+                )
+                if not old_id:
                     continue
-                old_id = str(account_number)
+                old_id = str(old_id)
                 if old_id in selected_accounts and old_id not in id_map:
                     new_id = validate_properties_data([raw_property])[0]["id"]
                     if new_id != old_id:

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.13.0"
+  "version": "1.13.1"
 }

--- a/tests/test_config_migration_v8.py
+++ b/tests/test_config_migration_v8.py
@@ -109,6 +109,61 @@ async def test_v7_entry_with_collapsed_account_id_gets_composite_ids():
 
 
 @pytest.mark.asyncio
+async def test_v7_entry_with_shared_property_physical_number_still_remaps_both():
+    """Regression test: some accounts have it the other way round from issue
+    #51 - propertyPhysicalNumber is the SHARED field (one physical address,
+    separate elec/gas billing accounts) and accountNumber is unique per
+    property. The old ID (pre-v8) fell through to accountNumber alone in
+    this shape, so both previously-selected properties must still be
+    remapped to their new composite IDs."""
+    entry = _make_config_entry(selected_accounts=["7471493", "8490263"])
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    raw_properties = [
+        {
+            "accountNumber": 7471493,
+            "propertyPhysicalNumber": 82227160,
+            "address": {"street": "27 SUNNYSIDE CRESCENT", "suburb": "CASTLECRAG"},
+            "consumers": [{"consumerNumber": 3000001, "utility": "E", "status": "ON"}],
+        },
+        {
+            "accountNumber": 8490263,
+            "propertyPhysicalNumber": 82227160,
+            "address": {"street": "27 SUNNYSIDE CRESCENT", "suburb": "CASTLECRAG"},
+            "consumers": [{"consumerNumber": 3000002, "utility": "G", "status": "ON"}],
+        },
+    ]
+
+    mock_device_registry = MagicMock()
+    mock_device_registry.async_get_device.return_value = None
+
+    mock_entity_registry = MagicMock()
+
+    with patch(
+        "custom_components.red_energy.api.RedEnergyAPI.authenticate",
+        new=AsyncMock(return_value=True),
+    ), patch(
+        "custom_components.red_energy.api.RedEnergyAPI.get_properties",
+        new=AsyncMock(return_value=raw_properties),
+    ), patch(
+        "homeassistant.helpers.aiohttp_client.async_get_clientsession",
+        return_value=MagicMock(),
+    ), patch(
+        "homeassistant.helpers.device_registry.async_get", return_value=mock_device_registry
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_get", return_value=mock_entity_registry
+    ):
+        migrator = RedEnergyConfigMigrator(hass)
+        result = await migrator._migrate_v7_to_v8(entry)
+
+    assert result is True
+
+    new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+    assert set(new_data["selected_accounts"]) == {"82227160.7471493", "82227160.8490263"}
+
+
+@pytest.mark.asyncio
 async def test_v7_entry_with_already_unique_ids_is_a_noop():
     """Properties that already had distinct accountNumbers keep their IDs."""
     entry = _make_config_entry(selected_accounts=["1000001"])


### PR DESCRIPTION
Follow-up to #53 / 1.13.0.

- The v7→v8 migration assumed the pre-migration property ID always came from `accountNumber` alone
- Some accounts have it reversed: `propertyPhysicalNumber` is the field shared across properties (one physical address, separate per-service billing accounts), and `accountNumber` is what was already unique per property
- For those accounts, the migration's lookup never matched `selected_accounts`, so it was left stale — breaking usage data matching for every property on the account (`matched 0, skipped 2`)
- The migration now reconstructs the old ID using the full pre-v8 fallback chain (`id` → `propertyId` → `property_id` → `accountNumber`) instead of assuming which field it was