### PR TITLE
fix: wire ConfigFlow.VERSION so migrations actually run

### DIFF
--- a/custom_components/red_energy/config_flow.py
+++ b/custom_components/red_energy/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers import config_validation as cv
 
 from .api import RedEnergyAPI, RedEnergyAPIError, RedEnergyAuthError
+from .config_migration import CURRENT_CONFIG_VERSION
 from .data_validation import validate_config_data, validate_properties_data, DataValidationError
 from .const import (
     CLIENT_ID,
@@ -132,7 +133,10 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Red Energy."""
 
-    VERSION = 1
+    # Must match CURRENT_CONFIG_VERSION in config_migration.py, or Home
+    # Assistant core will never call async_migrate_entry - it only migrates
+    # when an entry's stored version differs from this class attribute.
+    VERSION = CURRENT_CONFIG_VERSION
 
     def __init__(self) -> None:
         """Initialize the config flow."""
@@ -241,9 +245,16 @@ class RedEnergyOptionsFlowHandler(config_entries.OptionsFlow):
                 service_label = "/".join(
                     s.get("type", "").title() for s in account.get("services", []) if s.get("type")
                 )
-                account_options[account_id] = (
-                    f"{account_id} - {service_label}" if service_label else account_id
-                )
+                property_physical_number = account.get("property_physical_number")
+                account_number = account.get("account_number")
+                if property_physical_number and account_number and property_physical_number != account_number:
+                    label_parts = [property_physical_number, account_number, service_label]
+                else:
+                    # No distinct propertyPhysicalNumber/accountNumber pair
+                    # (e.g. synthetic ID fallback) - fall back to the id alone
+                    # rather than showing the same value twice.
+                    label_parts = [account_id, service_label]
+                account_options[account_id] = " - ".join(part for part in label_parts if part)
         except Exception as err:
             _LOGGER.warning("Could not refresh account list for options flow: %s", err)
             # Fall back to the accounts already known to the config entry so the

--- a/custom_components/red_energy/data_validation.py
+++ b/custom_components/red_energy/data_validation.py
@@ -150,6 +150,8 @@ def validate_single_property(data: dict[str, Any]) -> dict[str, Any]:
         "name": str(property_name),
         "address": validate_address(data.get("address", {})),
         "services": validate_services(services_data),
+        "property_physical_number": str(property_physical_number) if property_physical_number else None,
+        "account_number": str(account_number) if account_number else None,
     }
     
     _LOGGER.debug("Validated property: %s (ID: %s) with %d services", 

--- a/custom_components/red_energy/device_manager.py
+++ b/custom_components/red_energy/device_manager.py
@@ -64,7 +64,16 @@ class RedEnergyDeviceManager:
             s.get("type") for s in property_info.get("services", []) if s.get("type")
         ] or services
         service_label = "/".join(s.title() for s in account_services)
-        device_name = f"{account_id} - {service_label}" if service_label else str(account_id)
+        property_physical_number = property_info.get("property_physical_number")
+        account_number = property_info.get("account_number")
+        if property_physical_number and account_number and property_physical_number != account_number:
+            name_parts = [property_physical_number, account_number, service_label]
+        else:
+            # No distinct propertyPhysicalNumber/accountNumber pair (e.g.
+            # synthetic ID fallback) - fall back to the id alone rather than
+            # showing the same value twice.
+            name_parts = [str(account_id), service_label]
+        device_name = " - ".join(part for part in name_parts if part)
         address = property_info.get("address", {})
 
         # Create comprehensive device identifiers

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.13.2"
+  "version": "1.13.3"
 }

--- a/tests/test_config_flow_options_accounts.py
+++ b/tests/test_config_flow_options_accounts.py
@@ -14,9 +14,10 @@ MOCK_ENTRY_DATA = {
     "services": ["electricity"],
 }
 
-def _raw_property(account_number, utility, consumer_number):
+def _raw_property(account_number, utility, consumer_number, property_physical_number=None):
     return {
         "accountNumber": account_number,
+        "propertyPhysicalNumber": property_physical_number,
         "displayAddresses": {"shortForm": "27 Sunnyside Crescent, Castlecrag"},
         "address": {
             "suburb": "Castlecrag",
@@ -105,6 +106,33 @@ async def test_options_account_labels_use_account_id_not_shared_address():
     assert labels["1000001"] == "1000001 - Electricity"
     assert labels["2000002"] == "2000002 - Gas"
     assert "27 Sunnyside Crescent, Castlecrag" not in labels.values()
+
+
+@pytest.mark.asyncio
+async def test_options_account_labels_show_property_and_account_number():
+    """When propertyPhysicalNumber and accountNumber are both present and
+    distinct, labels must read 'Property Number - Account Number - Service'."""
+    properties = [
+        _raw_property(7471493, "E", 3000001, property_physical_number=82227160),
+        _raw_property(8490263, "G", 3000002, property_physical_number=82227160),
+    ]
+    entry = _make_config_entry()
+    entry.data = {**MOCK_ENTRY_DATA, DATA_SELECTED_ACCOUNTS: ["82227160.7471493"]}
+    hass = _make_hass(entry, properties=properties)
+
+    flow = RedEnergyOptionsFlowHandler()
+    flow.hass = hass
+    flow.handler = entry.entry_id
+
+    result = await flow.async_step_init()
+
+    accounts_validator = next(
+        v for k, v in result["data_schema"].schema.items() if str(k) == "accounts"
+    )
+    labels = accounts_validator.options
+
+    assert labels["82227160.7471493"] == "82227160 - 7471493 - Electricity"
+    assert labels["82227160.8490263"] == "82227160 - 8490263 - Gas"
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_migration_v9.py
+++ b/tests/test_config_migration_v9.py
@@ -136,3 +136,13 @@ async def test_v8_entry_with_matching_ids_is_a_noop():
 def test_config_version_9_is_current():
     assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_9
     assert CONFIG_VERSION_9 == 9
+
+
+def test_config_flow_version_matches_current_config_version():
+    """Home Assistant core only calls async_migrate_entry when
+    ConfigEntry.version != ConfigFlow.VERSION - if these two drift apart,
+    every migration in this file becomes dead code for existing entries,
+    regardless of how correct the migration logic itself is."""
+    from custom_components.red_energy.config_flow import ConfigFlow
+
+    assert ConfigFlow.VERSION == CURRENT_CONFIG_VERSION

--- a/tests/test_device_manager_split_accounts.py
+++ b/tests/test_device_manager_split_accounts.py
@@ -14,11 +14,13 @@ from custom_components.red_energy.device_manager import RedEnergyDeviceManager
 ADDRESS = {"street_address": "27 Sunnyside Crescent", "suburb": "Castlecrag"}
 
 
-def _property_info(name, service_type):
+def _property_info(name, service_type, property_physical_number=None, account_number=None):
     return {
         "name": name,
         "address": ADDRESS,
         "services": [{"type": service_type}],
+        "property_physical_number": property_physical_number,
+        "account_number": account_number,
     }
 
 
@@ -73,3 +75,34 @@ async def test_device_model_reflects_accounts_own_service_not_global_toggle():
 
     _, kwargs = manager._device_registry.async_get_or_create.call_args
     assert kwargs["model"] == "Gas Monitor"
+
+
+@pytest.mark.asyncio
+async def test_device_name_shows_property_and_account_number():
+    """When propertyPhysicalNumber and accountNumber are both present and
+    distinct, the device name must read 'Property Number - Account Number - Service'."""
+    manager = _make_device_manager()
+
+    electricity_device = await manager._create_property_device(
+        "82227160.7471493",
+        _property_info(
+            "27 Sunnyside Crescent, Castlecrag",
+            SERVICE_TYPE_ELECTRICITY,
+            property_physical_number="82227160",
+            account_number="7471493",
+        ),
+        [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
+    )
+    gas_device = await manager._create_property_device(
+        "82227160.8490263",
+        _property_info(
+            "27 Sunnyside Crescent, Castlecrag",
+            SERVICE_TYPE_GAS,
+            property_physical_number="82227160",
+            account_number="8490263",
+        ),
+        [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
+    )
+
+    assert electricity_device.name == "82227160 - 7471493 - Electricity"
+    assert gas_device.name == "82227160 - 8490263 - Gas"


### PR DESCRIPTION
Root cause of #51 follow-up: migrations never ran at all.

- Home Assistant core only calls `async_migrate_entry` when a config entry's stored `version` differs from `ConfigFlow.VERSION`
- `ConfigFlow.VERSION` was hardcoded to `1` and never kept in sync with the `CONFIG_VERSION_*` scheme in `config_migration.py` - so entries have been stuck at version 1 since creation, and every migration (v1 through v9) has never actually executed for any existing install
- `ConfigFlow.VERSION` now reads from `CURRENT_CONFIG_VERSION` directly so the two can't drift apart again
- Also fixes account labels (options flow picker and device names) to show `Property Number - Account Number - Service Type` instead of the opaque composite ID, falling back to the ID alone when the two numbers aren't both present and distinct