### PR TITLE
chore: scrub real address from test fixtures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,19 @@ Always work on a feature/fix branch — never commit directly to `main`. Create 
 
 When starting a new branch, bump the `version` field in `custom_components/red_energy/manifest.json` as the first commit, following semantic versioning (MAJOR.MINOR.PATCH): PATCH for bug fixes, MINOR for new features, MAJOR for breaking changes.
 
-## Account Numbers and Real Data
+## Personal Information and Real Data
 
-The user's real Red Energy account numbers, consumer numbers, and customer numbers (obtained during live debugging sessions, e.g. from a SQLite dump or live API response) must never be referenced or used outside the local conversation. This means:
+Never use real personal information — the user's own or anyone else's — anywhere it could end up committed: code, tests, fixtures, commit messages, PR descriptions/comments, or scratch/audit files. This includes but is not limited to:
 
-- Never commit real account/consumer/customer numbers in code, tests, commit messages, or PR descriptions/comments — use clearly-fake placeholder values instead (e.g. `1000001`, `2000002`).
-- Never write real account numbers into any file that gets committed to git, including scratch/audit files — if such a file is genuinely needed, keep it untracked (gitignored) and local-only.
-- This applies retroactively too: if a real number is found in already-tracked test fixtures or docs, replace it with a placeholder rather than leaving it as precedent for future work.
-- Account numbers aren't login credentials, but they're still real customer data belonging to the user (or whoever's account is being debugged) and shouldn't leak into a public repository's history going forward.
+- Account numbers, consumer numbers, customer numbers (Red Energy or otherwise)
+- Physical addresses, street names, suburbs (even ones that look innocuous, like a test fixture's "property address")
+- Names, emails, phone numbers, or other identifying details pulled from live debugging sessions (e.g. a SQLite dump, live API response, or log file)
+
+Always use clearly-fake example data instead — e.g. account numbers like `1000001`/`2000002`, addresses like `1 Example Street, Testville`, emails like `test@example.com`. This applies even when real data would make a test fixture or reproduction case more "realistic" — fake data that exercises the same code path is just as effective and carries no risk.
+
+- If a file containing real data is genuinely needed for local debugging, keep it untracked (gitignored) and local-only — never let it reach a commit.
+- This applies retroactively too: if real personal information is found in already-tracked files, replace it with a placeholder rather than leaving it as precedent for future work.
+- This data isn't necessarily a login credential, but it's still real personal information belonging to the user (or whoever's account/data is being debugged) and shouldn't leak into a public repository's history going forward.
 
 ## Commands
 

--- a/tests/test_config_flow_options_accounts.py
+++ b/tests/test_config_flow_options_accounts.py
@@ -18,12 +18,12 @@ def _raw_property(account_number, utility, consumer_number, property_physical_nu
     return {
         "accountNumber": account_number,
         "propertyPhysicalNumber": property_physical_number,
-        "displayAddresses": {"shortForm": "27 Sunnyside Crescent, Castlecrag"},
+        "displayAddresses": {"shortForm": "1 Example Street, Testville"},
         "address": {
-            "suburb": "Castlecrag",
+            "suburb": "Testville",
             "state": "NSW",
             "postcode": "2068",
-            "displayAddresses": {"shortForm": "27 Sunnyside Crescent, Castlecrag"},
+            "displayAddresses": {"shortForm": "1 Example Street, Testville"},
         },
         "consumers": [
             {
@@ -84,8 +84,8 @@ async def test_options_init_form_lists_newly_discovered_account():
 async def test_options_account_labels_use_account_id_not_shared_address():
     """Checkbox labels must disambiguate accounts sharing the same address.
 
-    Both mock properties share the display address "27 Sunnyside Crescent,
-    Castlecrag" (electricity and gas billed on separate accounts) - the
+    Both mock properties share the display address "1 Example Street,
+    Testville" (electricity and gas billed on separate accounts) - the
     label shown to the user must not be that address for both, or the
     options screen is unusable (matches the reported UI screenshot).
     """
@@ -105,7 +105,7 @@ async def test_options_account_labels_use_account_id_not_shared_address():
 
     assert labels["1000001"] == "1000001 - Electricity"
     assert labels["2000002"] == "2000002 - Gas"
-    assert "27 Sunnyside Crescent, Castlecrag" not in labels.values()
+    assert "1 Example Street, Testville" not in labels.values()
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_flow_options_accounts.py
+++ b/tests/test_config_flow_options_accounts.py
@@ -22,7 +22,7 @@ def _raw_property(account_number, utility, consumer_number, property_physical_nu
         "address": {
             "suburb": "Testville",
             "state": "NSW",
-            "postcode": "2068",
+            "postcode": "2000",
             "displayAddresses": {"shortForm": "1 Example Street, Testville"},
         },
         "consumers": [

--- a/tests/test_config_migration_v8.py
+++ b/tests/test_config_migration_v8.py
@@ -123,13 +123,13 @@ async def test_v7_entry_with_shared_property_physical_number_still_remaps_both()
         {
             "accountNumber": 7471493,
             "propertyPhysicalNumber": 82227160,
-            "address": {"street": "27 SUNNYSIDE CRESCENT", "suburb": "CASTLECRAG"},
+            "address": {"street": "1 EXAMPLE STREET", "suburb": "TESTVILLE"},
             "consumers": [{"consumerNumber": 3000001, "utility": "E", "status": "ON"}],
         },
         {
             "accountNumber": 8490263,
             "propertyPhysicalNumber": 82227160,
-            "address": {"street": "27 SUNNYSIDE CRESCENT", "suburb": "CASTLECRAG"},
+            "address": {"street": "1 EXAMPLE STREET", "suburb": "TESTVILLE"},
             "consumers": [{"consumerNumber": 3000002, "utility": "G", "status": "ON"}],
         },
     ]

--- a/tests/test_config_migration_v9.py
+++ b/tests/test_config_migration_v9.py
@@ -48,13 +48,13 @@ async def test_v8_entry_stuck_with_stale_ids_gets_repaired():
         {
             "accountNumber": 7471493,
             "propertyPhysicalNumber": 82227160,
-            "address": {"street": "27 SUNNYSIDE CRESCENT", "suburb": "CASTLECRAG"},
+            "address": {"street": "1 EXAMPLE STREET", "suburb": "TESTVILLE"},
             "consumers": [{"consumerNumber": 3000001, "utility": "E", "status": "ON"}],
         },
         {
             "accountNumber": 8490263,
             "propertyPhysicalNumber": 82227160,
-            "address": {"street": "27 SUNNYSIDE CRESCENT", "suburb": "CASTLECRAG"},
+            "address": {"street": "1 EXAMPLE STREET", "suburb": "TESTVILLE"},
             "consumers": [{"consumerNumber": 3000002, "utility": "G", "status": "ON"}],
         },
     ]
@@ -106,7 +106,7 @@ async def test_v8_entry_with_matching_ids_is_a_noop():
         {
             "accountNumber": 7471493,
             "propertyPhysicalNumber": 82227160,
-            "address": {"street": "27 SUNNYSIDE CRESCENT", "suburb": "CASTLECRAG"},
+            "address": {"street": "1 EXAMPLE STREET", "suburb": "TESTVILLE"},
             "consumers": [{"consumerNumber": 3000001, "utility": "E", "status": "ON"}],
         },
     ]

--- a/tests/test_data_validation_errors.py
+++ b/tests/test_data_validation_errors.py
@@ -257,16 +257,16 @@ def test_validate_address_handles_partial_none_values():
     """Test address with some None and some string values."""
     address = {
         "house": None,
-        "street": "SUNNYSIDE CRES",
-        "suburb": "CASTLECRAG",
+        "street": "EXAMPLE STREET",
+        "suburb": "TESTVILLE",
         "state": "NSW",
-        "postcode": "2068",
+        "postcode": "2000",
     }
     result = validate_address(address)
-    assert result["street"] == "SUNNYSIDE CRES"
-    assert result["city"] == "CASTLECRAG"
+    assert result["street"] == "EXAMPLE STREET"
+    assert result["city"] == "TESTVILLE"
     assert result["state"] == "NSW"
-    assert result["postcode"] == "2068"
+    assert result["postcode"] == "2000"
 
 
 def test_validate_usage_entry_allday_tariff_no_warning(caplog):
@@ -330,10 +330,10 @@ def test_validate_properties_data_handles_address_with_none_house():
             "accountNumber": 1000001,
             "address": {
                 "house": None,
-                "street": "SUNNYSIDE CRES",
-                "suburb": "CASTLECRAG",
+                "street": "EXAMPLE STREET",
+                "suburb": "TESTVILLE",
                 "state": "NSW",
-                "postcode": "2068",
+                "postcode": "2000",
             },
             "consumers": [
                 {
@@ -347,10 +347,10 @@ def test_validate_properties_data_handles_address_with_none_house():
     result = validate_properties_data(raw_properties)
     assert len(result) == 1
     assert result[0]["id"] == "1000001"
-    assert result[0]["address"]["street"] == "SUNNYSIDE CRES"
-    assert result[0]["address"]["city"] == "CASTLECRAG"
+    assert result[0]["address"]["street"] == "EXAMPLE STREET"
+    assert result[0]["address"]["city"] == "TESTVILLE"
     assert result[0]["address"]["state"] == "NSW"
-    assert result[0]["address"]["postcode"] == "2068"
+    assert result[0]["address"]["postcode"] == "2000"
 
 
 def test_validate_properties_data_shared_account_number_stays_distinct():

--- a/tests/test_device_manager_split_accounts.py
+++ b/tests/test_device_manager_split_accounts.py
@@ -11,7 +11,7 @@ from custom_components.red_energy.const import (
 )
 from custom_components.red_energy.device_manager import RedEnergyDeviceManager
 
-ADDRESS = {"street_address": "27 Sunnyside Crescent", "suburb": "Castlecrag"}
+ADDRESS = {"street_address": "1 Example Street", "suburb": "Testville"}
 
 
 def _property_info(name, service_type, property_physical_number=None, account_number=None):
@@ -48,12 +48,12 @@ async def test_split_accounts_at_same_address_get_distinct_device_names():
 
     electricity_device = await manager._create_property_device(
         "1000001",
-        _property_info("27 Sunnyside Crescent, Castlecrag", SERVICE_TYPE_ELECTRICITY),
+        _property_info("1 Example Street, Testville", SERVICE_TYPE_ELECTRICITY),
         [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
     )
     gas_device = await manager._create_property_device(
         "2000002",
-        _property_info("27 Sunnyside Crescent, Castlecrag", SERVICE_TYPE_GAS),
+        _property_info("1 Example Street, Testville", SERVICE_TYPE_GAS),
         [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
     )
 
@@ -69,7 +69,7 @@ async def test_device_model_reflects_accounts_own_service_not_global_toggle():
 
     await manager._create_property_device(
         "2000002",
-        _property_info("27 Sunnyside Crescent, Castlecrag", SERVICE_TYPE_GAS),
+        _property_info("1 Example Street, Testville", SERVICE_TYPE_GAS),
         [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
     )
 
@@ -86,7 +86,7 @@ async def test_device_name_shows_property_and_account_number():
     electricity_device = await manager._create_property_device(
         "82227160.7471493",
         _property_info(
-            "27 Sunnyside Crescent, Castlecrag",
+            "1 Example Street, Testville",
             SERVICE_TYPE_ELECTRICITY,
             property_physical_number="82227160",
             account_number="7471493",
@@ -96,7 +96,7 @@ async def test_device_name_shows_property_and_account_number():
     gas_device = await manager._create_property_device(
         "82227160.8490263",
         _property_info(
-            "27 Sunnyside Crescent, Castlecrag",
+            "1 Example Street, Testville",
             SERVICE_TYPE_GAS,
             property_physical_number="82227160",
             account_number="8490263",

--- a/tests/test_sensor_basic_meter_disabled.py
+++ b/tests/test_sensor_basic_meter_disabled.py
@@ -15,7 +15,7 @@ def _coordinator_for_basic_gas_meter():
         "usage_data": {
             "2000002": {
                 "property": {
-                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "name": "1 Example Street, Testville",
                     "services": [
                         {
                             "type": SERVICE_TYPE_GAS,
@@ -47,7 +47,7 @@ def _coordinator_for_interval_electricity_meter():
         "usage_data": {
             "1000001": {
                 "property": {
-                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "name": "1 Example Street, Testville",
                     "services": [
                         {
                             "type": SERVICE_TYPE_ELECTRICITY,

--- a/tests/test_sensor_electricity_only_and_diagnostics.py
+++ b/tests/test_sensor_electricity_only_and_diagnostics.py
@@ -42,10 +42,10 @@ def _coordinator(service_metadata, service_type):
         "usage_data": {
             "2000002": {
                 "property": {
-                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "name": "1 Example Street, Testville",
                     "address": {
-                        "street": "27 Sunnyside Crescent",
-                        "city": "Castlecrag",
+                        "street": "1 Example Street",
+                        "city": "Testville",
                         "state": "NSW",
                         "postcode": "2068",
                     },
@@ -165,7 +165,7 @@ def test_address_sensor_formats_full_address():
 
     sensor = RedEnergyAddressSensor(coordinator, config_entry, "2000002", SERVICE_TYPE_GAS)
 
-    assert sensor.native_value == "27 Sunnyside Crescent, Castlecrag NSW 2068"
+    assert sensor.native_value == "1 Example Street, Testville NSW 2068"
 
 
 def test_address_sensor_exposes_latitude_longitude_attributes():

--- a/tests/test_sensor_electricity_only_and_diagnostics.py
+++ b/tests/test_sensor_electricity_only_and_diagnostics.py
@@ -47,7 +47,7 @@ def _coordinator(service_metadata, service_type):
                         "street": "1 Example Street",
                         "city": "Testville",
                         "state": "NSW",
-                        "postcode": "2068",
+                        "postcode": "2000",
                     },
                     "services": [service_metadata],
                 },
@@ -165,7 +165,7 @@ def test_address_sensor_formats_full_address():
 
     sensor = RedEnergyAddressSensor(coordinator, config_entry, "2000002", SERVICE_TYPE_GAS)
 
-    assert sensor.native_value == "1 Example Street, Testville NSW 2068"
+    assert sensor.native_value == "1 Example Street, Testville NSW 2000"
 
 
 def test_address_sensor_exposes_latitude_longitude_attributes():

--- a/tests/test_sensor_setup_split_accounts.py
+++ b/tests/test_sensor_setup_split_accounts.py
@@ -15,13 +15,13 @@ def _coordinator_for_split_accounts():
         "usage_data": {
             "1000001": {
                 "property": {
-                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "name": "1 Example Street, Testville",
                     "services": [{"type": SERVICE_TYPE_ELECTRICITY, "consumer_number": "elec-1"}],
                 },
             },
             "2000002": {
                 "property": {
-                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "name": "1 Example Street, Testville",
                     "services": [{"type": SERVICE_TYPE_GAS, "consumer_number": "gas-1"}],
                 },
             },

--- a/tests/test_sensor_stale_entity_cleanup.py
+++ b/tests/test_sensor_stale_entity_cleanup.py
@@ -15,7 +15,7 @@ def _coordinator_for_single_account():
         "usage_data": {
             "1000001": {
                 "property": {
-                    "name": "27 Sunnyside Crescent, Castlecrag",
+                    "name": "1 Example Street, Testville",
                     "services": [{"type": SERVICE_TYPE_ELECTRICITY, "consumer_number": "elec-1"}],
                 },
             },


### PR DESCRIPTION
- Replaces a real address that had been used in several test fixtures with a placeholder (\`1 Example Street, Testville\`)
- Broadens the CLAUDE.md real-data rule to cover addresses and personal information generally, not just account numbers