### PR TITLE
feat: show address and account number in device names

### DIFF
--- a/custom_components/red_energy/config_flow.py
+++ b/custom_components/red_energy/config_flow.py
@@ -16,7 +16,12 @@ from homeassistant.helpers import config_validation as cv
 
 from .api import RedEnergyAPI, RedEnergyAPIError, RedEnergyAuthError
 from .config_migration import CURRENT_CONFIG_VERSION
-from .data_validation import validate_config_data, validate_properties_data, DataValidationError
+from .data_validation import (
+    build_property_display_name,
+    validate_config_data,
+    validate_properties_data,
+    DataValidationError,
+)
 from .const import (
     CLIENT_ID,
     CONF_ENABLE_ADVANCED_SENSORS,
@@ -245,16 +250,9 @@ class RedEnergyOptionsFlowHandler(config_entries.OptionsFlow):
                 service_label = "/".join(
                     s.get("type", "").title() for s in account.get("services", []) if s.get("type")
                 )
-                property_physical_number = account.get("property_physical_number")
-                account_number = account.get("account_number")
-                if property_physical_number and account_number and property_physical_number != account_number:
-                    label_parts = [property_physical_number, account_number, service_label]
-                else:
-                    # No distinct propertyPhysicalNumber/accountNumber pair
-                    # (e.g. synthetic ID fallback) - fall back to the id alone
-                    # rather than showing the same value twice.
-                    label_parts = [account_id, service_label]
-                account_options[account_id] = " - ".join(part for part in label_parts if part)
+                account_options[account_id] = build_property_display_name(
+                    account_id, account, service_label
+                )
         except Exception as err:
             _LOGGER.warning("Could not refresh account list for options flow: %s", err)
             # Fall back to the accounts already known to the config entry so the

--- a/custom_components/red_energy/data_validation.py
+++ b/custom_components/red_energy/data_validation.py
@@ -12,6 +12,20 @@ class DataValidationError(Exception):
     """Exception raised when data validation fails."""
 
 
+def build_property_display_name(property_id: str, validated_property: dict[str, Any], service_label: str) -> str:
+    """Build the "{address} - {service} ({accountNumber})" display name used
+    for devices and account picker labels. Falls back to the property ID when
+    the address or account number aren't available (e.g. synthetic IDs)."""
+    address = validated_property.get("extra_short_form") or str(property_id)
+    account_number = validated_property.get("account_number")
+
+    name_parts = [address, service_label]
+    display_name = " - ".join(part for part in name_parts if part)
+    if account_number:
+        display_name = f"{display_name} ({account_number})"
+    return display_name
+
+
 def validate_customer_data(data: dict[str, Any]) -> dict[str, Any]:
     """Validate customer data from Red Energy API."""
     if not isinstance(data, dict):
@@ -117,29 +131,39 @@ def validate_single_property(data: dict[str, Any]) -> dict[str, Any]:
     
     # Get property name - try various fields
     property_name = data.get("name") or data.get("propertyName")
-    
+
+    address_data = data.get("address", {})
+    display_addresses = (
+        address_data.get("displayAddresses", {}) if isinstance(address_data, dict) else {}
+    )
+    if not isinstance(display_addresses, dict):
+        display_addresses = {}
+
+    # extraShortForm (e.g. "100 Main Street") is the preferred short label for
+    # device/entity display names - shorter than shortForm, which usually
+    # includes the suburb too.
+    extra_short_form = display_addresses.get("extraShortForm")
+
     # If no name, try to build from address
     if not property_name:
-        address_data = data.get("address", {})
-        if isinstance(address_data, dict):
-            # Try display address fields first
-            display_addresses = address_data.get("displayAddresses", {})
-            if isinstance(display_addresses, dict):
-                property_name = display_addresses.get("shortForm") or display_addresses.get("extraShortForm")
-            
-            # Fall back to building from address parts
-            if not property_name:
-                house = (address_data.get("house") or "").strip()
-                street = (address_data.get("street") or "").strip()
-                suburb = (address_data.get("suburb") or "").strip()
-                if house and street and suburb:
-                    property_name = f"{house} {street}, {suburb}"
-                elif street and suburb:
-                    property_name = f"{street}, {suburb}"
-    
+        property_name = display_addresses.get("shortForm") or extra_short_form
+
+        # Fall back to building from address parts
+        if not property_name and isinstance(address_data, dict):
+            house = (address_data.get("house") or "").strip()
+            street = (address_data.get("street") or "").strip()
+            suburb = (address_data.get("suburb") or "").strip()
+            if house and street and suburb:
+                property_name = f"{house} {street}, {suburb}"
+            elif street and suburb:
+                property_name = f"{street}, {suburb}"
+
     # Final fallback
     if not property_name:
         property_name = f"Property {property_id}"
+
+    if not extra_short_form:
+        extra_short_form = property_name
     
     # API can return either "services" or "consumers"
     services_data = data.get("services") or data.get("consumers", [])
@@ -152,6 +176,7 @@ def validate_single_property(data: dict[str, Any]) -> dict[str, Any]:
         "services": validate_services(services_data),
         "property_physical_number": str(property_physical_number) if property_physical_number else None,
         "account_number": str(account_number) if account_number else None,
+        "extra_short_form": str(extra_short_form),
     }
     
     _LOGGER.debug("Validated property: %s (ID: %s) with %d services", 

--- a/custom_components/red_energy/device_manager.py
+++ b/custom_components/red_energy/device_manager.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN, MANUFACTURER, SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS
+from .data_validation import build_property_display_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -64,16 +65,7 @@ class RedEnergyDeviceManager:
             s.get("type") for s in property_info.get("services", []) if s.get("type")
         ] or services
         service_label = "/".join(s.title() for s in account_services)
-        property_physical_number = property_info.get("property_physical_number")
-        account_number = property_info.get("account_number")
-        if property_physical_number and account_number and property_physical_number != account_number:
-            name_parts = [property_physical_number, account_number, service_label]
-        else:
-            # No distinct propertyPhysicalNumber/accountNumber pair (e.g.
-            # synthetic ID fallback) - fall back to the id alone rather than
-            # showing the same value twice.
-            name_parts = [str(account_id), service_label]
-        device_name = " - ".join(part for part in name_parts if part)
+        device_name = build_property_display_name(account_id, property_info, service_label)
         address = property_info.get("address", {})
 
         # Create comprehensive device identifiers

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.13.3"
+  "version": "1.14.0"
 }

--- a/tests/test_config_flow_options_accounts.py
+++ b/tests/test_config_flow_options_accounts.py
@@ -23,7 +23,10 @@ def _raw_property(account_number, utility, consumer_number, property_physical_nu
             "suburb": "Testville",
             "state": "NSW",
             "postcode": "2000",
-            "displayAddresses": {"shortForm": "1 Example Street, Testville"},
+            "displayAddresses": {
+                "shortForm": "1 Example Street, Testville",
+                "extraShortForm": "1 Example Street",
+            },
         },
         "consumers": [
             {
@@ -81,13 +84,13 @@ async def test_options_init_form_lists_newly_discovered_account():
 
 
 @pytest.mark.asyncio
-async def test_options_account_labels_use_account_id_not_shared_address():
+async def test_options_account_labels_use_account_number_not_shared_address():
     """Checkbox labels must disambiguate accounts sharing the same address.
 
     Both mock properties share the display address "1 Example Street,
     Testville" (electricity and gas billed on separate accounts) - the
-    label shown to the user must not be that address for both, or the
-    options screen is unusable (matches the reported UI screenshot).
+    account number in parentheses must disambiguate them, or the options
+    screen is unusable (matches the reported UI screenshot).
     """
     entry = _make_config_entry()
     hass = _make_hass(entry)
@@ -103,15 +106,15 @@ async def test_options_account_labels_use_account_id_not_shared_address():
     )
     labels = accounts_validator.options
 
-    assert labels["1000001"] == "1000001 - Electricity"
-    assert labels["2000002"] == "2000002 - Gas"
-    assert "1 Example Street, Testville" not in labels.values()
+    assert labels["1000001"] == "1 Example Street - Electricity (1000001)"
+    assert labels["2000002"] == "1 Example Street - Gas (2000002)"
+    assert labels["1000001"] != labels["2000002"]
 
 
 @pytest.mark.asyncio
-async def test_options_account_labels_show_property_and_account_number():
-    """When propertyPhysicalNumber and accountNumber are both present and
-    distinct, labels must read 'Property Number - Account Number - Service'."""
+async def test_options_account_labels_show_address_and_account_number():
+    """Labels must read '{address} - {service} ({accountNumber})', using
+    extraShortForm for the address rather than the internal composite ID."""
     properties = [
         _raw_property(7471493, "E", 3000001, property_physical_number=82227160),
         _raw_property(8490263, "G", 3000002, property_physical_number=82227160),
@@ -131,8 +134,8 @@ async def test_options_account_labels_show_property_and_account_number():
     )
     labels = accounts_validator.options
 
-    assert labels["82227160.7471493"] == "82227160 - 7471493 - Electricity"
-    assert labels["82227160.8490263"] == "82227160 - 8490263 - Gas"
+    assert labels["82227160.7471493"] == "1 Example Street - Electricity (7471493)"
+    assert labels["82227160.8490263"] == "1 Example Street - Gas (8490263)"
 
 
 @pytest.mark.asyncio

--- a/tests/test_device_manager_split_accounts.py
+++ b/tests/test_device_manager_split_accounts.py
@@ -14,13 +14,14 @@ from custom_components.red_energy.device_manager import RedEnergyDeviceManager
 ADDRESS = {"street_address": "1 Example Street", "suburb": "Testville"}
 
 
-def _property_info(name, service_type, property_physical_number=None, account_number=None):
+def _property_info(name, service_type, property_physical_number=None, account_number=None, extra_short_form=None):
     return {
         "name": name,
         "address": ADDRESS,
         "services": [{"type": service_type}],
         "property_physical_number": property_physical_number,
         "account_number": account_number,
+        "extra_short_form": extra_short_form or name,
     }
 
 
@@ -48,18 +49,22 @@ async def test_split_accounts_at_same_address_get_distinct_device_names():
 
     electricity_device = await manager._create_property_device(
         "1000001",
-        _property_info("1 Example Street, Testville", SERVICE_TYPE_ELECTRICITY),
+        _property_info(
+            "1 Example Street, Testville", SERVICE_TYPE_ELECTRICITY, account_number="1000001"
+        ),
         [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
     )
     gas_device = await manager._create_property_device(
         "2000002",
-        _property_info("1 Example Street, Testville", SERVICE_TYPE_GAS),
+        _property_info(
+            "1 Example Street, Testville", SERVICE_TYPE_GAS, account_number="2000002"
+        ),
         [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
     )
 
     assert electricity_device.name != gas_device.name
-    assert electricity_device.name == "1000001 - Electricity"
-    assert gas_device.name == "2000002 - Gas"
+    assert electricity_device.name == "1 Example Street, Testville - Electricity (1000001)"
+    assert gas_device.name == "1 Example Street, Testville - Gas (2000002)"
 
 
 @pytest.mark.asyncio
@@ -78,9 +83,9 @@ async def test_device_model_reflects_accounts_own_service_not_global_toggle():
 
 
 @pytest.mark.asyncio
-async def test_device_name_shows_property_and_account_number():
-    """When propertyPhysicalNumber and accountNumber are both present and
-    distinct, the device name must read 'Property Number - Account Number - Service'."""
+async def test_device_name_shows_address_service_and_account_number():
+    """Device name must read '{address} - {service} ({accountNumber})', using
+    extraShortForm for the address rather than the internal composite ID."""
     manager = _make_device_manager()
 
     electricity_device = await manager._create_property_device(
@@ -90,6 +95,7 @@ async def test_device_name_shows_property_and_account_number():
             SERVICE_TYPE_ELECTRICITY,
             property_physical_number="82227160",
             account_number="7471493",
+            extra_short_form="100 Main Street",
         ),
         [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
     )
@@ -100,9 +106,10 @@ async def test_device_name_shows_property_and_account_number():
             SERVICE_TYPE_GAS,
             property_physical_number="82227160",
             account_number="8490263",
+            extra_short_form="100 Main Street",
         ),
         [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
     )
 
-    assert electricity_device.name == "82227160 - 7471493 - Electricity"
-    assert gas_device.name == "82227160 - 8490263 - Gas"
+    assert electricity_device.name == "100 Main Street - Electricity (7471493)"
+    assert gas_device.name == "100 Main Street - Gas (8490263)"


### PR DESCRIPTION
- Device names and the options-flow account picker now read `{address} - {service} ({accountNumber})`, e.g. `100 Main Street - Gas (100001)`
- Uses the address's `extraShortForm` (e.g. "100 Main Street") instead of the internal composite property ID
- Both call sites (device_manager.py, config_flow.py) share one `build_property_display_name` helper so the format stays consistent
- Cosmetic only - doesn't touch entity `unique_id` or device identifiers, so no migration needed and no history impact