### PR TITLE
fix: clear stale Okta cookies before each auth attempt

### DIFF
--- a/custom_components/red_energy/api.py
+++ b/custom_components/red_energy/api.py
@@ -34,7 +34,17 @@ class RedEnergyAPI:
     REDIRECT_URI = "au.com.redenergy://callback"
     BASE_API_URL = "https://selfservice.services.retail.energy/v1"
     OKTA_AUTH_URL = "https://redenergy.okta.com/api/v1/authn"
-    
+
+    # Domains involved in the cookie-sensitive Okta /authn -> /authorize
+    # handshake. Home Assistant's aiohttp session is shared and its cookie
+    # jar persists across every config-entry reload, so a stale session
+    # cookie (e.g. JSESSIONID) from a previous, abandoned auth attempt can
+    # desync Okta's server-side session state and break the next attempt's
+    # redirect - even though that attempt sends a fresh sessionToken/PKCE
+    # pair. selfservice.services.retail.energy (the data API) is excluded:
+    # it's bearer-token only and never sets or reads cookies.
+    OKTA_COOKIE_DOMAINS: tuple[str, ...] = ("redenergy.okta.com", "login.redenergy.com.au")
+
     def __init__(self, session: aiohttp.ClientSession) -> None:
         """Initialize the API client."""
         self._session = session
@@ -52,7 +62,15 @@ class RedEnergyAPI:
         state and cause the authorization redirect to fail.
         """
         async with self._auth_lock:
+            self._clear_auth_cookies()
             return await self._authenticate_locked(username, password)
+
+    def _clear_auth_cookies(self) -> None:
+        """Clear leftover Okta/Red Energy session cookies before a fresh
+        auth attempt, so state from a previous (possibly abandoned) attempt
+        on this shared session can't desync Okta's server-side session."""
+        for domain in self.OKTA_COOKIE_DOMAINS:
+            self._session.cookie_jar.clear_domain(domain)
 
     async def _authenticate_locked(self, username: str, password: str) -> bool:
         try:

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.14.0"
+  "version": "1.14.1"
 }

--- a/tests/test_api_auth_concurrency.py
+++ b/tests/test_api_auth_concurrency.py
@@ -57,3 +57,47 @@ async def test_concurrent_authenticate_calls_do_not_overlap(api_client, monkeypa
 
     assert results == [True, True]
     assert max_concurrent == 1
+
+
+@pytest.mark.asyncio
+async def test_authenticate_clears_stale_auth_cookies_before_starting(monkeypatch):
+    """A fresh authenticate() call must clear any leftover Okta/Red Energy
+    session cookies before starting the /authn -> /authorize handshake.
+
+    Home Assistant's global aiohttp session is reused across every config
+    entry reload, so cookies from a previous, now-abandoned auth attempt
+    (e.g. a stale JSESSIONID) can linger and desync Okta's server-side
+    session state from the fresh sessionToken/PKCE parameters being sent,
+    causing /authorize to return an HTML error page instead of a redirect.
+    """
+    session = AsyncMock()
+    session.cookie_jar = AsyncMock()
+    api = RedEnergyAPI(session)
+
+    async def fake_get_session_token(username, password):
+        return "session_token", "2099-01-01T00:00:00.000Z"
+
+    async def fake_get_discovery_data():
+        return {
+            "authorization_endpoint": "https://example.okta.com/authorize",
+            "token_endpoint": "https://example.okta.com/token",
+        }
+
+    async def fake_get_authorization_code(auth_endpoint, session_token, client_id, code_challenge):
+        return "auth_code"
+
+    async def fake_exchange_code_for_tokens(token_endpoint, auth_code, client_id, code_verifier):
+        api._access_token = "access_token"
+        api._refresh_token = "refresh_token"
+
+    monkeypatch.setattr(api, "_get_session_token", fake_get_session_token)
+    monkeypatch.setattr(api, "_get_discovery_data", fake_get_discovery_data)
+    monkeypatch.setattr(api, "_get_authorization_code", fake_get_authorization_code)
+    monkeypatch.setattr(api, "_exchange_code_for_tokens", fake_exchange_code_for_tokens)
+
+    result = await api.authenticate("user", "pass")
+
+    assert result is True
+    assert session.cookie_jar.clear_domain.call_count == len(RedEnergyAPI.OKTA_COOKIE_DOMAINS)
+    cleared_domains = {call.args[0] for call in session.cookie_jar.clear_domain.call_args_list}
+    assert cleared_domains == set(RedEnergyAPI.OKTA_COOKIE_DOMAINS)


### PR DESCRIPTION
- Home Assistant's global aiohttp session persists cookies across every config-entry reload
- A stale JSESSIONID cookie from a previous, abandoned auth attempt could desync Okta's server-side session state from a fresh sessionToken/PKCE pair, causing /authorize to return an HTML error page instead of a redirect
- Most visible right after reconfiguring (e.g. adding an account via the options flow), which triggers a reload and a brand new auth attempt sharing the same session
- Clears cookies scoped to the two auth-relevant domains (redenergy.okta.com, login.redenergy.com.au) at the start of every authenticate() call