### PR TITLE
fix: daily sensor state class and boundary bugs

### DIFF
--- a/custom_components/red_energy/api.py
+++ b/custom_components/red_energy/api.py
@@ -622,6 +622,7 @@ class RedEnergyAPI:
         # Max demand tracking
         max_demand_kw = 0.0
         max_demand_time = None
+        demand_data_available = False
         
         # Process each 30-minute interval (48 per day)
         breakdown_available = False
@@ -694,7 +695,8 @@ class RedEnergyAPI:
                 
                 # Track max demand from interval detail
                 demand_detail = interval.get("demandDetail", {})
-                if isinstance(demand_detail, dict):
+                if isinstance(demand_detail, dict) and demand_detail:
+                    demand_data_available = True
                     demand_kw = float(demand_detail.get("demandKw", 0.0))
                     if demand_kw > max_demand_kw:
                         max_demand_kw = demand_kw
@@ -728,6 +730,7 @@ class RedEnergyAPI:
         max_demand_detail = entry.get("maxDemandDetail", {})
         if isinstance(max_demand_detail, dict) and max_demand_detail:
             # Use correct field names from API response
+            demand_data_available = True
             daily_max_demand = float(max_demand_detail.get("maxDemandKw", 0.0))
             if daily_max_demand > max_demand_kw:
                 max_demand_kw = daily_max_demand
@@ -767,7 +770,7 @@ class RedEnergyAPI:
             "shoulder_export_usage": round(shoulder_export, 3),
             
             # Demand and environmental
-            "max_demand_kw": round(max_demand_kw, 3),
+            "max_demand_kw": round(max_demand_kw, 3) if demand_data_available else None,
             "max_demand_time": max_demand_time,
             "carbon_emission_tonne": round(carbon_emission, 6),
             
@@ -795,7 +798,7 @@ class RedEnergyAPI:
             "peak_export_usage": 0.0,
             "offpeak_export_usage": 0.0,
             "shoulder_export_usage": 0.0,
-            "max_demand_kw": 0.0,
+            "max_demand_kw": None,
             "max_demand_time": None,
             "carbon_emission_tonne": 0.0
         }

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -77,20 +77,23 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         last_bill_date = service.get("lastBillDate")
         if last_bill_date:
             try:
-                start_date = datetime.strptime(last_bill_date, "%Y-%m-%d")
-                
+                # lastBillDate is the final day of the *previous* billing period,
+                # so the new period's usage starts the following day - otherwise
+                # that day's usage/cost is double-counted across both periods.
+                start_date = datetime.strptime(last_bill_date, "%Y-%m-%d") + timedelta(days=1)
+
                 if start_date > end_date:
                     _LOGGER.warning("lastBillDate %s is in the future, falling back to 30-day period", last_bill_date)
                     start_date = None
                 elif (end_date - start_date).days > 90:
-                    _LOGGER.warning("lastBillDate %s is >90 days old (%d days), this may be a long billing period", 
+                    _LOGGER.warning("lastBillDate %s is >90 days old (%d days), this may be a long billing period",
                                   last_bill_date, (end_date - start_date).days)
                 else:
-                    _LOGGER.info("Using billing period: %s to %s (%d days)", 
-                               start_date.strftime('%Y-%m-%d'), 
+                    _LOGGER.info("Using billing period: %s to %s (%d days)",
+                               start_date.strftime('%Y-%m-%d'),
                                end_date.strftime('%Y-%m-%d'),
                                (end_date - start_date).days)
-                    
+
             except (ValueError, TypeError) as err:
                 _LOGGER.warning("Invalid lastBillDate format '%s': %s, falling back to 30-day period", last_bill_date, err)
                 start_date = None
@@ -589,29 +592,41 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
 
         return metadata.get("rates", [])
 
-    def get_latest_import_usage(self, property_id: str, service_type: str) -> float | None:
-        """Get the most recent daily import usage."""
+    def _get_latest_usage_entry(self, property_id: str, service_type: str) -> dict[str, Any] | None:
+        """Return the usage_data entry with the latest usageDate.
+
+        Selects by max date rather than assuming the API returns entries
+        in order, so results stay correct if the API ever returns them
+        out of order.
+        """
         service_data = self.get_service_usage(property_id, service_type)
         if not service_data or "usage_data" not in service_data:
             return None
-        
+
         usage_data = service_data["usage_data"].get("usage_data", [])
         if not usage_data:
             return None
-        
-        return usage_data[-1].get("import_usage", 0.0)
+
+        dated_entries = [entry for entry in usage_data if entry.get("date")]
+        if not dated_entries:
+            return usage_data[-1]
+
+        return max(dated_entries, key=lambda entry: entry["date"])
+
+    def get_latest_usage_date(self, property_id: str, service_type: str) -> str | None:
+        """Get the usageDate of the most recent daily usage entry."""
+        entry = self._get_latest_usage_entry(property_id, service_type)
+        return entry.get("date") if entry else None
+
+    def get_latest_import_usage(self, property_id: str, service_type: str) -> float | None:
+        """Get the most recent daily import usage."""
+        entry = self._get_latest_usage_entry(property_id, service_type)
+        return entry.get("import_usage", 0.0) if entry else None
 
     def get_latest_export_usage(self, property_id: str, service_type: str) -> float | None:
         """Get the most recent daily export usage."""
-        service_data = self.get_service_usage(property_id, service_type)
-        if not service_data or "usage_data" not in service_data:
-            return None
-        
-        usage_data = service_data["usage_data"].get("usage_data", [])
-        if not usage_data:
-            return None
-        
-        return usage_data[-1].get("export_usage", 0.0)
+        entry = self._get_latest_usage_entry(property_id, service_type)
+        return entry.get("export_usage", 0.0) if entry else None
 
     def get_total_import_usage(self, property_id: str, service_type: str) -> float | None:
         """Get total import usage over period."""
@@ -689,17 +704,22 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         if not usage_data:
             return None
         
-        max_demand_kw = 0.0
+        max_demand_kw = None
         max_demand_time = None
         max_demand_date = None
-        
+
         for entry in usage_data:
-            demand = entry.get("max_demand_kw", 0.0)
-            if demand > max_demand_kw:
+            demand = entry.get("max_demand_kw")
+            if demand is None:
+                continue
+            if max_demand_kw is None or demand > max_demand_kw:
                 max_demand_kw = demand
                 max_demand_time = entry.get("max_demand_time")
                 max_demand_date = entry.get("date")
-        
+
+        if max_demand_kw is None:
+            return None
+
         return {
             "max_demand_kw": max_demand_kw,
             "max_demand_time": max_demand_time,
@@ -717,24 +737,10 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
 
     def get_latest_import_cost(self, property_id: str, service_type: str) -> float | None:
         """Get the most recent daily import cost."""
-        service_data = self.get_service_usage(property_id, service_type)
-        if not service_data or "usage_data" not in service_data:
-            return None
-        
-        usage_data = service_data["usage_data"].get("usage_data", [])
-        if not usage_data:
-            return None
-        
-        return usage_data[-1].get("import_cost", 0.0)
+        entry = self._get_latest_usage_entry(property_id, service_type)
+        return entry.get("import_cost", 0.0) if entry else None
 
     def get_latest_export_credit(self, property_id: str, service_type: str) -> float | None:
         """Get the most recent daily export credit."""
-        service_data = self.get_service_usage(property_id, service_type)
-        if not service_data or "usage_data" not in service_data:
-            return None
-        
-        usage_data = service_data["usage_data"].get("usage_data", [])
-        if not usage_data:
-            return None
-        
-        return usage_data[-1].get("export_credit", 0.0)
+        entry = self._get_latest_usage_entry(property_id, service_type)
+        return entry.get("export_credit", 0.0) if entry else None

--- a/custom_components/red_energy/data_validation.py
+++ b/custom_components/red_energy/data_validation.py
@@ -438,7 +438,7 @@ def validate_usage_entry(data: dict[str, Any]) -> dict[str, Any]:
     
     # Validate all numeric fields
     for field in numeric_fields:
-        if field in data:
+        if field in data and data[field] is not None:
             try:
                 value = float(data[field])
                 # Handle negative values appropriately based on field type

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.14.1"
+  "version": "1.14.2"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -296,6 +296,22 @@ class RedEnergyBaseSensor(CoordinatorEntity, SensorEntity):
         except (ValueError, TypeError):
             return None
 
+    def _get_latest_usage_date_reset(self) -> datetime | None:
+        """Return the start of the latest usageDate as a UTC datetime for last_reset.
+
+        Daily sensors publish a new independent completed-day total on every
+        update, so each one needs its own reset boundary - otherwise HA's sum
+        statistics treat successive daily totals as deltas of one continuous
+        accumulation instead of separate one-day totals.
+        """
+        usage_date = self.coordinator.get_latest_usage_date(self._property_id, self._service_type)
+        if not usage_date:
+            return None
+        try:
+            return dt_util.as_utc(datetime.strptime(usage_date, "%Y-%m-%d"))
+        except (ValueError, TypeError):
+            return None
+
 
 class RedEnergyCostSensor(RedEnergyBaseSensor):
     """Red Energy total cost sensor."""
@@ -1154,6 +1170,11 @@ class RedEnergyDailyImportUsageSensor(RedEnergyBaseSensor):
             self._attr_state_class = SensorStateClass.TOTAL
 
     @property
+    def last_reset(self) -> datetime | None:
+        """Return the start of the represented usageDate so HA statistics don't sum across days."""
+        return self._get_latest_usage_date_reset()
+
+    @property
     def native_value(self) -> float | None:
         """Return the current daily import usage."""
         return self.coordinator.get_latest_import_usage(self._property_id, self._service_type)
@@ -1198,6 +1219,11 @@ class RedEnergyDailyExportUsageSensor(RedEnergyBaseSensor):
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_native_unit_of_measurement = "MJ"
             self._attr_state_class = SensorStateClass.TOTAL
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the start of the represented usageDate so HA statistics don't sum across days."""
+        return self._get_latest_usage_date_reset()
 
     @property
     def native_value(self) -> float | None:
@@ -1439,6 +1465,11 @@ class RedEnergyDailyImportCostSensor(RedEnergyBaseSensor):
         self._attr_state_class = SensorStateClass.TOTAL
 
     @property
+    def last_reset(self) -> datetime | None:
+        """Return the start of the represented usageDate so HA statistics don't sum across days."""
+        return self._get_latest_usage_date_reset()
+
+    @property
     def native_value(self) -> float | None:
         """Return the current daily import cost."""
         return self.coordinator.get_latest_import_cost(self._property_id, self._service_type)
@@ -1479,6 +1510,11 @@ class RedEnergyDailyExportCreditSensor(RedEnergyBaseSensor):
         self._attr_native_unit_of_measurement = "AUD"
         self._attr_state_class = SensorStateClass.TOTAL
         self._attr_icon = "mdi:solar-power"
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the start of the represented usageDate so HA statistics don't sum across days."""
+        return self._get_latest_usage_date_reset()
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -429,7 +429,13 @@ class RedEnergyMonthlyAverageSensor(RedEnergyBaseSensor):
 
 
 class RedEnergyPeakUsageSensor(RedEnergyBaseSensor):
-    """Red Energy peak daily usage sensor."""
+    """Red Energy highest net grid usage day sensor.
+
+    Despite the "peak_usage" sensor_type/entity_id (kept for unique_id
+    backward compatibility), this is not a TOU peak-period or demand-peak
+    figure - it's the single day with the highest net (import - export)
+    usage across the returned period.
+    """
 
     def __init__(
         self,
@@ -440,7 +446,8 @@ class RedEnergyPeakUsageSensor(RedEnergyBaseSensor):
     ) -> None:
         """Initialize the peak usage sensor."""
         super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_PEAK_USAGE)
-        
+        self._attr_name = "Highest Net Usage Day"
+
         if service_type == SERVICE_TYPE_ELECTRICITY:
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
@@ -452,16 +459,16 @@ class RedEnergyPeakUsageSensor(RedEnergyBaseSensor):
 
     @property
     def native_value(self) -> float | None:
-        """Return the peak daily usage."""
+        """Return the highest daily net usage (import - export)."""
         service_data = self.coordinator.get_service_usage(self._property_id, self._service_type)
         if not service_data or "usage_data" not in service_data:
             return None
-        
+
         usage_data = service_data["usage_data"].get("usage_data", [])
         if not usage_data:
             return None
-        
-        # Find peak daily usage
+
+        # Find the day with the highest net usage
         usage_values = [entry.get("usage", 0) for entry in usage_data]
         return max(usage_values) if usage_values else 0
 
@@ -471,16 +478,17 @@ class RedEnergyPeakUsageSensor(RedEnergyBaseSensor):
         service_data = self.coordinator.get_service_usage(self._property_id, self._service_type)
         if not service_data or "usage_data" not in service_data:
             return None
-        
+
         usage_data = service_data["usage_data"].get("usage_data", [])
         if not usage_data:
             return None
-        
-        # Find peak date
+
+        # Find the day with the highest net usage
         peak_entry = max(usage_data, key=lambda x: x.get("usage", 0))
-        
+
         return {
             "consumer_number": service_data.get("consumer_number"),
+            "description": "Day with the highest net (import - export) grid usage in the period, not a TOU peak-period or demand figure",
             "peak_date": peak_entry.get("date"),
             "peak_cost": peak_entry.get("cost"),
             "service_type": self._service_type,
@@ -1139,11 +1147,11 @@ class RedEnergyDailyImportUsageSensor(RedEnergyBaseSensor):
         if service_type == SERVICE_TYPE_ELECTRICITY:
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+            self._attr_state_class = SensorStateClass.TOTAL
         elif service_type == SERVICE_TYPE_GAS:
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_native_unit_of_measurement = "MJ"
-            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+            self._attr_state_class = SensorStateClass.TOTAL
 
     @property
     def native_value(self) -> float | None:
@@ -1160,6 +1168,7 @@ class RedEnergyDailyImportUsageSensor(RedEnergyBaseSensor):
         return {
             "consumer_number": service_data.get("consumer_number"),
             "last_updated": service_data.get("last_updated"),
+            "usage_date": self.coordinator.get_latest_usage_date(self._property_id, self._service_type),
             "service_type": self._service_type,
             "description": "Grid import (consumption)"
         }
@@ -1183,12 +1192,12 @@ class RedEnergyDailyExportUsageSensor(RedEnergyBaseSensor):
         if service_type == SERVICE_TYPE_ELECTRICITY:
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+            self._attr_state_class = SensorStateClass.TOTAL
             self._attr_icon = "mdi:solar-power"
         elif service_type == SERVICE_TYPE_GAS:
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_native_unit_of_measurement = "MJ"
-            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+            self._attr_state_class = SensorStateClass.TOTAL
 
     @property
     def native_value(self) -> float | None:
@@ -1205,6 +1214,7 @@ class RedEnergyDailyExportUsageSensor(RedEnergyBaseSensor):
         return {
             "consumer_number": service_data.get("consumer_number"),
             "last_updated": service_data.get("last_updated"),
+            "usage_date": self.coordinator.get_latest_usage_date(self._property_id, self._service_type),
             "service_type": self._service_type,
             "description": "Solar export (generation)"
         }
@@ -1443,6 +1453,7 @@ class RedEnergyDailyImportCostSensor(RedEnergyBaseSensor):
         return {
             "consumer_number": service_data.get("consumer_number"),
             "last_updated": service_data.get("last_updated"),
+            "usage_date": self.coordinator.get_latest_usage_date(self._property_id, self._service_type),
             "service_type": self._service_type,
             "gst_inclusive": False,
             "description": "Cost of grid import for latest day"
@@ -1484,6 +1495,7 @@ class RedEnergyDailyExportCreditSensor(RedEnergyBaseSensor):
         return {
             "consumer_number": service_data.get("consumer_number"),
             "last_updated": service_data.get("last_updated"),
+            "usage_date": self.coordinator.get_latest_usage_date(self._property_id, self._service_type),
             "service_type": self._service_type,
             "description": "Credit from solar export for latest day"
         }

--- a/tests/test_issue_62_fixes.py
+++ b/tests/test_issue_62_fixes.py
@@ -2,11 +2,12 @@
 
 Covers: daily energy sensor state class, max demand null-vs-zero,
 "Peak Usage" sensor renaming, billing period boundary double-count,
-and latest-day selection by usageDate instead of list position.
+latest-day selection by usageDate instead of list position, and
+per-day last_reset on the daily TOTAL sensors.
 """
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from homeassistant.components.sensor import SensorStateClass
 
@@ -15,6 +16,8 @@ from custom_components.red_energy.data_validation import validate_usage_entry
 from custom_components.red_energy.sensor import (
     RedEnergyDailyImportUsageSensor,
     RedEnergyDailyExportUsageSensor,
+    RedEnergyDailyImportCostSensor,
+    RedEnergyDailyExportCreditSensor,
     RedEnergyPeakUsageSensor,
 )
 from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY
@@ -216,3 +219,50 @@ class TestLatestDaySelection:
             coordinator, _config_entry(), "prop-001", SERVICE_TYPE_ELECTRICITY
         )
         assert sensor.extra_state_attributes["usage_date"] == "2024-01-15"
+
+
+class TestDailySensorLastReset:
+    """Follow-up from #62: daily TOTAL sensors need last_reset tied to usageDate.
+
+    Without a reset boundary that moves with each new completed day, HA's
+    sum statistics treat successive independent daily totals as deltas of
+    one continuous accumulation (e.g. $6.20 -> $4.80 -> $7.10 would net out
+    to a negative delta on day 2 instead of three separate daily totals).
+    """
+
+    @pytest.mark.parametrize(
+        "sensor_cls",
+        [
+            RedEnergyDailyImportUsageSensor,
+            RedEnergyDailyExportUsageSensor,
+            RedEnergyDailyImportCostSensor,
+            RedEnergyDailyExportCreditSensor,
+        ],
+    )
+    def test_last_reset_matches_usage_date(self, coordinator, sensor_cls):
+        _set_service_usage(
+            coordinator,
+            [{"date": "2024-01-15", "import_usage": 10.0, "export_usage": 2.0,
+              "import_cost": 3.0, "export_credit": 0.5}],
+        )
+        sensor = sensor_cls(coordinator, _config_entry(), "prop-001", SERVICE_TYPE_ELECTRICITY)
+
+        assert sensor.last_reset == datetime(2024, 1, 15, tzinfo=timezone.utc)
+
+    def test_last_reset_moves_to_new_day_on_next_update(self, coordinator):
+        sensor = RedEnergyDailyImportUsageSensor(
+            coordinator, _config_entry(), "prop-001", SERVICE_TYPE_ELECTRICITY
+        )
+
+        _set_service_usage(coordinator, [{"date": "2024-01-15", "import_usage": 10.0}])
+        assert sensor.last_reset == datetime(2024, 1, 15, tzinfo=timezone.utc)
+
+        _set_service_usage(coordinator, [{"date": "2024-01-16", "import_usage": 4.0}])
+        assert sensor.last_reset == datetime(2024, 1, 16, tzinfo=timezone.utc)
+
+    def test_last_reset_none_when_no_usage_data(self, coordinator):
+        _set_service_usage(coordinator, [])
+        sensor = RedEnergyDailyImportUsageSensor(
+            coordinator, _config_entry(), "prop-001", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.last_reset is None

--- a/tests/test_issue_62_fixes.py
+++ b/tests/test_issue_62_fixes.py
@@ -1,0 +1,218 @@
+"""Tests for the bug fixes tracked in GitHub issue #62.
+
+Covers: daily energy sensor state class, max demand null-vs-zero,
+"Peak Usage" sensor renaming, billing period boundary double-count,
+and latest-day selection by usageDate instead of list position.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timedelta
+
+from homeassistant.components.sensor import SensorStateClass
+
+from custom_components.red_energy.coordinator import RedEnergyDataCoordinator
+from custom_components.red_energy.data_validation import validate_usage_entry
+from custom_components.red_energy.sensor import (
+    RedEnergyDailyImportUsageSensor,
+    RedEnergyDailyExportUsageSensor,
+    RedEnergyPeakUsageSensor,
+)
+from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY
+
+
+@pytest.fixture
+def mock_hass():
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock()
+    return hass
+
+
+@pytest.fixture
+def coordinator(mock_hass):
+    with patch(
+        "custom_components.red_energy.coordinator.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        coord = RedEnergyDataCoordinator(
+            hass=mock_hass,
+            username="test_user",
+            password="test_pass",
+            selected_accounts=["prop-001"],
+            services=["electricity"],
+        )
+    coord.api = AsyncMock()
+    coord.api._access_token = "test_token"
+    return coord
+
+
+def _usage_service_data(usage_entries, consumer_number="elec-123"):
+    return {
+        "consumer_number": consumer_number,
+        "last_updated": "2024-01-30T10:00:00",
+        "usage_data": {
+            "from_date": "2024-01-01",
+            "to_date": "2024-01-30",
+            "usage_data": usage_entries,
+        },
+    }
+
+
+def _set_service_usage(coordinator, usage_entries):
+    coordinator.data = {
+        "usage_data": {
+            "prop-001": {
+                "services": {
+                    "electricity": _usage_service_data(usage_entries),
+                }
+            }
+        }
+    }
+
+
+def _config_entry():
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    return entry
+
+
+class TestDailyEnergySensorStateClass:
+    """Bug #1: daily import/export usage sensors should be TOTAL, not TOTAL_INCREASING."""
+
+    def test_daily_import_usage_is_total_not_total_increasing(self, coordinator):
+        sensor = RedEnergyDailyImportUsageSensor(
+            coordinator, _config_entry(), "prop-001", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.state_class == SensorStateClass.TOTAL
+
+    def test_daily_export_usage_is_total_not_total_increasing(self, coordinator):
+        sensor = RedEnergyDailyExportUsageSensor(
+            coordinator, _config_entry(), "prop-001", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.state_class == SensorStateClass.TOTAL
+
+
+class TestMaxDemandNullVsZero:
+    """Bug #2: max demand should be None (unavailable), not 0.0, when no plan has demand data."""
+
+    def test_returns_none_when_no_interval_has_demand_detail(self, coordinator):
+        _set_service_usage(
+            coordinator,
+            [
+                {"date": "2024-01-01", "import_usage": 10.0, "max_demand_kw": None},
+                {"date": "2024-01-02", "import_usage": 12.0, "max_demand_kw": None},
+            ],
+        )
+        assert coordinator.get_max_demand_data("prop-001", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_validate_usage_entry_accepts_null_max_demand_kw(self):
+        """Regression check: None must not blow up validate_usage_entry's float() coercion."""
+        entry = {
+            "date": "2024-01-01",
+            "usage": 10.0,
+            "cost": 3.0,
+            "import_usage": 10.0,
+            "export_usage": 0.0,
+            "import_cost": 3.0,
+            "export_credit": 0.0,
+            "net_cost": 3.0,
+            "max_demand_kw": None,
+            "carbon_emission_tonne": 0.001,
+        }
+        validated = validate_usage_entry(entry)
+        assert validated.get("max_demand_kw") is None
+
+    def test_returns_actual_value_when_demand_data_present(self, coordinator):
+        _set_service_usage(
+            coordinator,
+            [
+                {"date": "2024-01-01", "import_usage": 10.0, "max_demand_kw": None},
+                {
+                    "date": "2024-01-02",
+                    "import_usage": 12.0,
+                    "max_demand_kw": 5.2,
+                    "max_demand_time": "2024-01-02T18:00:00",
+                },
+            ],
+        )
+        result = coordinator.get_max_demand_data("prop-001", SERVICE_TYPE_ELECTRICITY)
+        assert result["max_demand_kw"] == 5.2
+        assert result["max_demand_date"] == "2024-01-02"
+
+
+class TestPeakUsageSensorRenamed:
+    """Bug #3: sensor formerly named "Peak Usage" should be clearly relabeled."""
+
+    def test_name_no_longer_says_peak_usage(self, coordinator):
+        sensor = RedEnergyPeakUsageSensor(
+            coordinator, _config_entry(), "prop-001", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor._attr_name == "Highest Net Usage Day"
+
+    def test_unique_id_unchanged_for_backward_compatibility(self, coordinator):
+        sensor = RedEnergyPeakUsageSensor(
+            coordinator, _config_entry(), "prop-001", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor._attr_unique_id.endswith("_peak_usage")
+
+
+class TestBillingPeriodBoundary:
+    """Bug #4: lastBillDate is the last day of the *previous* period and must be excluded."""
+
+    def test_start_date_is_day_after_last_bill_date(self, coordinator):
+        last_bill_date = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%d")
+        service = {"lastBillDate": last_bill_date}
+
+        start_date, _end_date = coordinator._get_usage_period_dates(service)
+
+        expected_start = datetime.strptime(last_bill_date, "%Y-%m-%d") + timedelta(days=1)
+        assert start_date.date() == expected_start.date()
+
+    def test_falls_back_to_30_days_when_last_bill_date_missing(self, coordinator):
+        start_date, end_date = coordinator._get_usage_period_dates({})
+        assert (end_date - start_date).days == 30
+
+
+class TestLatestDaySelection:
+    """Bug #5: latest-day values should be selected by max usageDate, not list position."""
+
+    def test_selects_max_date_even_when_out_of_order(self, coordinator):
+        _set_service_usage(
+            coordinator,
+            [
+                {"date": "2024-01-15", "import_usage": 99.0, "export_usage": 9.0,
+                 "import_cost": 20.0, "export_credit": 2.0},
+                {"date": "2024-01-10", "import_usage": 5.0, "export_usage": 1.0,
+                 "import_cost": 1.5, "export_credit": 0.3},
+            ],
+        )
+
+        assert coordinator.get_latest_import_usage("prop-001", SERVICE_TYPE_ELECTRICITY) == 99.0
+        assert coordinator.get_latest_export_usage("prop-001", SERVICE_TYPE_ELECTRICITY) == 9.0
+        assert coordinator.get_latest_import_cost("prop-001", SERVICE_TYPE_ELECTRICITY) == 20.0
+        assert coordinator.get_latest_export_credit("prop-001", SERVICE_TYPE_ELECTRICITY) == 2.0
+        assert coordinator.get_latest_usage_date("prop-001", SERVICE_TYPE_ELECTRICITY) == "2024-01-15"
+
+    def test_falls_back_to_last_entry_when_dates_missing(self, coordinator):
+        _set_service_usage(
+            coordinator,
+            [
+                {"import_usage": 5.0},
+                {"import_usage": 42.0},
+            ],
+        )
+        assert coordinator.get_latest_import_usage("prop-001", SERVICE_TYPE_ELECTRICITY) == 42.0
+
+    def test_returns_none_when_no_usage_data(self, coordinator):
+        _set_service_usage(coordinator, [])
+        assert coordinator.get_latest_import_usage("prop-001", SERVICE_TYPE_ELECTRICITY) is None
+        assert coordinator.get_latest_usage_date("prop-001", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_sensor_exposes_usage_date_attribute(self, coordinator):
+        _set_service_usage(
+            coordinator,
+            [{"date": "2024-01-15", "import_usage": 99.0, "export_usage": 9.0}],
+        )
+        sensor = RedEnergyDailyImportUsageSensor(
+            coordinator, _config_entry(), "prop-001", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.extra_state_attributes["usage_date"] == "2024-01-15"


### PR DESCRIPTION
Fixes #62.

- Daily import/export usage sensors now use `TOTAL` instead of `TOTAL_INCREASING`, since each day is an independent value that can legitimately be lower than the previous day
- Max demand now reports unavailable (`None`) instead of `0.0` when no plan/interval has demand data, avoiding a false zero-kW reading
- "Peak Usage" sensor renamed to "Highest Net Usage Day" to avoid confusion with TOU peak-period or demand-peak figures (`unique_id` unchanged for backward compatibility)
- Billing period start date now begins the day after `lastBillDate`, fixing a day double-counted across billing periods
- Latest-day coordinator methods now select the entry with the max `usageDate` instead of assuming API list order, and expose `usage_date` as an attribute on the daily sensors

Scope refined per follow-up review in #62's comments (state class correction to `TOTAL` not `MEASUREMENT`, confirmed billing boundary bug, added max-date selection requirement).