### PR TITLE
feat: daily & billing period service charge sensors

### DIFF
--- a/custom_components/red_energy/const.py
+++ b/custom_components/red_energy/const.py
@@ -90,6 +90,8 @@ SENSOR_TYPE_STATUS: Final = "status"
 SENSOR_TYPE_ADDRESS: Final = "address"
 SENSOR_TYPE_PAYMENT_TYPE: Final = "payment_type"
 SENSOR_TYPE_RATE_PREFIX: Final = "rate"
+SENSOR_TYPE_DAILY_SERVICE_CHARGE: Final = "daily_service_charge"
+SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE: Final = "billing_period_service_charge"
 
 # Configuration options
 CONF_SCAN_INTERVAL: Final = "scan_interval"

--- a/custom_components/red_energy/const.py
+++ b/custom_components/red_energy/const.py
@@ -90,7 +90,6 @@ SENSOR_TYPE_STATUS: Final = "status"
 SENSOR_TYPE_ADDRESS: Final = "address"
 SENSOR_TYPE_PAYMENT_TYPE: Final = "payment_type"
 SENSOR_TYPE_RATE_PREFIX: Final = "rate"
-SENSOR_TYPE_DAILY_SERVICE_CHARGE: Final = "daily_service_charge"
 SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE: Final = "billing_period_service_charge"
 
 # Configuration options

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -629,11 +629,6 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
             None,
         )
 
-    def get_daily_service_charge(self, property_id: str, service_type: str) -> float | None:
-        """Get the daily service/supply charge amount, GST-inclusive."""
-        rate = self._find_service_charge_rate(property_id, service_type)
-        return rate.get("rate_incl_gst_dollars") if rate else None
-
     def get_billing_period_service_charge(self, property_id: str, service_type: str) -> float | None:
         """Get the accumulated service charge from the billing period start
         through the latest completed usageDate, inclusive.

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -615,6 +615,25 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
 
         return metadata.get("rates", [])
 
+    def _find_service_charge_rate(self, property_id: str, service_type: str) -> dict[str, Any] | None:
+        """Find the daily service/supply charge rate for a property and service.
+
+        Identified by type == "SC" and unit == "day" together - neither
+        field alone reliably distinguishes the service charge from other
+        rates on the same plan. If more than one rate matches, the first
+        in list order is used.
+        """
+        rates = self.get_service_rates(property_id, service_type)
+        return next(
+            (r for r in rates if r.get("type") == "SC" and r.get("unit") == "day"),
+            None,
+        )
+
+    def get_daily_service_charge(self, property_id: str, service_type: str) -> float | None:
+        """Get the daily service/supply charge amount, GST-inclusive."""
+        rate = self._find_service_charge_rate(property_id, service_type)
+        return rate.get("rate_incl_gst_dollars") if rate else None
+
     def get_cl2_inference(self, property_id: str, service_type: str) -> dict[str, Any] | None:
         """Aggregate CL2/TOU inference across a service's usage period.
 

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -634,6 +634,36 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         rate = self._find_service_charge_rate(property_id, service_type)
         return rate.get("rate_incl_gst_dollars") if rate else None
 
+    def get_billing_period_service_charge(self, property_id: str, service_type: str) -> float | None:
+        """Get the accumulated service charge from the billing period start
+        through the latest completed usageDate, inclusive.
+
+        Uses the latest completed usageDate as the period end - not
+        datetime.now() - so a day with no confirmed usage data yet is
+        never counted as a represented day.
+        """
+        rate = self._find_service_charge_rate(property_id, service_type)
+        if rate is None:
+            return None
+
+        latest_usage_date_str = self.get_latest_usage_date(property_id, service_type)
+        if not latest_usage_date_str:
+            return None
+
+        try:
+            billing_period_end = datetime.strptime(latest_usage_date_str, "%Y-%m-%d").date()
+        except (ValueError, TypeError):
+            return None
+
+        service_metadata = self.get_service_metadata(property_id, service_type) or {}
+        billing_period_start = self._get_billing_period_start(service_metadata).date()
+
+        if billing_period_end < billing_period_start:
+            return None
+
+        represented_day_count = (billing_period_end - billing_period_start).days + 1
+        return rate["rate_incl_gst_dollars"] * represented_day_count
+
     def get_cl2_inference(self, property_id: str, service_type: str) -> dict[str, Any] | None:
         """Aggregate CL2/TOU inference across a service's usage period.
 

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -71,16 +71,21 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
 
-    def _get_usage_period_dates(self, service: dict[str, Any]) -> tuple[datetime, datetime]:
+    def _get_billing_period_start(self, service: dict[str, Any]) -> datetime:
+        """Resolve the current billing period's start date.
+
+        lastBillDate is the final day of the *previous* billing period, so
+        the new period's usage starts the following day - otherwise that
+        day's usage/cost is double-counted across both periods. Falls back
+        to a 30-day window when lastBillDate is missing, invalid, in the
+        future, or implausibly old (>90 days).
+        """
         end_date = datetime.now()
         start_date = None
-        
+
         last_bill_date = service.get("lastBillDate")
         if last_bill_date:
             try:
-                # lastBillDate is the final day of the *previous* billing period,
-                # so the new period's usage starts the following day - otherwise
-                # that day's usage/cost is double-counted across both periods.
                 start_date = datetime.strptime(last_bill_date, "%Y-%m-%d") + timedelta(days=1)
 
                 if start_date > end_date:
@@ -98,13 +103,18 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
             except (ValueError, TypeError) as err:
                 _LOGGER.warning("Invalid lastBillDate format '%s': %s, falling back to 30-day period", last_bill_date, err)
                 start_date = None
-        
+
         if start_date is None:
             start_date = end_date - timedelta(days=30)
-            _LOGGER.info("Using 30-day fallback period: %s to %s", 
-                       start_date.strftime('%Y-%m-%d'), 
+            _LOGGER.info("Using 30-day fallback period: %s to %s",
+                       start_date.strftime('%Y-%m-%d'),
                        end_date.strftime('%Y-%m-%d'))
-        
+
+        return start_date
+
+    def _get_usage_period_dates(self, service: dict[str, Any]) -> tuple[datetime, datetime]:
+        end_date = datetime.now()
+        start_date = self._get_billing_period_start(service)
         return start_date, end_date
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.16.2"
+  "version": "1.17.0"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -27,6 +27,7 @@ from .const import (
     SENSOR_TYPE_ARREARS,
     SENSOR_TYPE_BALANCE,
     SENSOR_TYPE_BILLING_FREQUENCY,
+    SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE,
     SENSOR_TYPE_CHARGE_CLASS,
     SENSOR_TYPE_CL2_COST,
     SENSOR_TYPE_CL2_ENERGY,
@@ -34,6 +35,7 @@ from .const import (
     SENSOR_TYPE_CORRECTED_PEAK_IMPORT,
     SENSOR_TYPE_CORRECTED_SHOULDER_IMPORT,
     SENSOR_TYPE_DAILY_AVERAGE,
+    SENSOR_TYPE_DAILY_SERVICE_CHARGE,
     SENSOR_TYPE_DISTRIBUTOR,
     SENSOR_TYPE_EFFICIENCY,
     SENSOR_TYPE_JURISDICTION,
@@ -159,6 +161,9 @@ async def async_setup_entry(
                     RedEnergyMaxDemandSensor(coordinator, config_entry, account_id, service_type),
                     RedEnergyMaxDemandTimeSensor(coordinator, config_entry, account_id, service_type),
                     RedEnergyCarbonEmissionSensor(coordinator, config_entry, account_id, service_type),
+                    # NEW: Service/supply charge sensors
+                    RedEnergyDailyServiceChargeSensor(coordinator, config_entry, account_id, service_type),
+                    RedEnergyBillingPeriodServiceChargeSensor(coordinator, config_entry, account_id, service_type),
                 ])
 
             # CL2/TOU derived sensors - only for accounts whose plan
@@ -866,6 +871,132 @@ class RedEnergyRateSensor(RedEnergyBaseSensor):
             return None
 
         return {key: value for key, value in rate.items() if key != "rate_incl_gst_dollars"}
+
+
+class RedEnergyDailyServiceChargeSensor(RedEnergyBaseSensor):
+    """Red Energy daily service/supply charge sensor.
+
+    Represents the service charge for the latest completed usageDate,
+    derived from the plan's daily supply-charge rate (type "SC", unit
+    "day"). Unavailable when the plan has no such rate.
+    """
+
+    def __init__(
+        self,
+        coordinator: RedEnergyDataCoordinator,
+        config_entry: ConfigEntry,
+        property_id: str,
+        service_type: str,
+    ) -> None:
+        """Initialize the daily service charge sensor."""
+        super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_DAILY_SERVICE_CHARGE)
+
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_native_unit_of_measurement = "AUD"
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_icon = "mdi:currency-usd"
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the start of the represented usageDate so HA statistics don't sum across days."""
+        return self._get_latest_usage_date_reset()
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the daily service charge, GST-inclusive."""
+        return self.coordinator.get_daily_service_charge(self._property_id, self._service_type)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return the rate basis and calculation for the daily service charge."""
+        rate = self.coordinator._find_service_charge_rate(self._property_id, self._service_type)
+        if rate is None:
+            return None
+
+        rate_incl_gst = rate.get("rate_incl_gst_dollars")
+        rate_excl_gst_cents = rate.get("rate_excl_gst_cents")
+        rate_excl_gst = round(rate_excl_gst_cents / 100, 5) if rate_excl_gst_cents is not None else None
+
+        return {
+            "usage_date": self.coordinator.get_latest_usage_date(self._property_id, self._service_type),
+            "service_rate_incl_gst": rate_incl_gst,
+            "service_rate_excl_gst": rate_excl_gst,
+            "represented_day_count": 1,
+            "calculation": "service_rate_incl_gst × 1 day",
+        }
+
+
+class RedEnergyBillingPeriodServiceChargeSensor(RedEnergyBaseSensor):
+    """Red Energy billing period service/supply charge sensor.
+
+    Represents the accumulated service charge from the start of the
+    current billing period through the latest completed usageDate,
+    inclusive. Unavailable when the plan has no daily supply-charge
+    rate, or when the represented day count cannot be determined.
+    """
+
+    def __init__(
+        self,
+        coordinator: RedEnergyDataCoordinator,
+        config_entry: ConfigEntry,
+        property_id: str,
+        service_type: str,
+    ) -> None:
+        """Initialize the billing period service charge sensor."""
+        super().__init__(
+            coordinator, config_entry, property_id, service_type, SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE
+        )
+
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_native_unit_of_measurement = "AUD"
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_icon = "mdi:currency-usd"
+
+    def _billing_period_start_date(self) -> datetime | None:
+        service_metadata = self.coordinator.get_service_metadata(self._property_id, self._service_type) or {}
+        return self.coordinator._get_billing_period_start(service_metadata)
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the billing period start date so HA statistics reset correctly."""
+        start_date = self._billing_period_start_date()
+        if start_date is None:
+            return None
+        return dt_util.as_utc(start_date)
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the accumulated billing period service charge, GST-inclusive."""
+        return self.coordinator.get_billing_period_service_charge(self._property_id, self._service_type)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return the rate basis, day count, and calculation for the billing period service charge."""
+        if self.native_value is None:
+            return None
+
+        rate = self.coordinator._find_service_charge_rate(self._property_id, self._service_type)
+        latest_usage_date = self.coordinator.get_latest_usage_date(self._property_id, self._service_type)
+        billing_period_start = self._billing_period_start_date()
+
+        rate_incl_gst = rate.get("rate_incl_gst_dollars") if rate else None
+        rate_excl_gst_cents = rate.get("rate_excl_gst_cents") if rate else None
+        rate_excl_gst = round(rate_excl_gst_cents / 100, 5) if rate_excl_gst_cents is not None else None
+
+        represented_day_count = None
+        if billing_period_start is not None and latest_usage_date:
+            end_date = datetime.strptime(latest_usage_date, "%Y-%m-%d").date()
+            represented_day_count = (end_date - billing_period_start.date()).days + 1
+
+        return {
+            "billing_period_start": billing_period_start.strftime("%Y-%m-%d") if billing_period_start else None,
+            "billing_period_end": latest_usage_date,
+            "latest_usage_date": latest_usage_date,
+            "represented_day_count": represented_day_count,
+            "service_rate_incl_gst": rate_incl_gst,
+            "service_rate_excl_gst": rate_excl_gst,
+            "calculation": f"service_rate_incl_gst × {represented_day_count} days",
+        }
 
 
 class RedEnergyAddressSensor(RedEnergyBaseSensor):

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -35,7 +35,6 @@ from .const import (
     SENSOR_TYPE_CORRECTED_PEAK_IMPORT,
     SENSOR_TYPE_CORRECTED_SHOULDER_IMPORT,
     SENSOR_TYPE_DAILY_AVERAGE,
-    SENSOR_TYPE_DAILY_SERVICE_CHARGE,
     SENSOR_TYPE_DISTRIBUTOR,
     SENSOR_TYPE_EFFICIENCY,
     SENSOR_TYPE_JURISDICTION,
@@ -161,8 +160,7 @@ async def async_setup_entry(
                     RedEnergyMaxDemandSensor(coordinator, config_entry, account_id, service_type),
                     RedEnergyMaxDemandTimeSensor(coordinator, config_entry, account_id, service_type),
                     RedEnergyCarbonEmissionSensor(coordinator, config_entry, account_id, service_type),
-                    # NEW: Service/supply charge sensors
-                    RedEnergyDailyServiceChargeSensor(coordinator, config_entry, account_id, service_type),
+                    # NEW: Service/supply charge sensor
                     RedEnergyBillingPeriodServiceChargeSensor(coordinator, config_entry, account_id, service_type),
                 ])
 
@@ -871,59 +869,6 @@ class RedEnergyRateSensor(RedEnergyBaseSensor):
             return None
 
         return {key: value for key, value in rate.items() if key != "rate_incl_gst_dollars"}
-
-
-class RedEnergyDailyServiceChargeSensor(RedEnergyBaseSensor):
-    """Red Energy daily service/supply charge sensor.
-
-    Represents the service charge for the latest completed usageDate,
-    derived from the plan's daily supply-charge rate (type "SC", unit
-    "day"). Unavailable when the plan has no such rate.
-    """
-
-    def __init__(
-        self,
-        coordinator: RedEnergyDataCoordinator,
-        config_entry: ConfigEntry,
-        property_id: str,
-        service_type: str,
-    ) -> None:
-        """Initialize the daily service charge sensor."""
-        super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_DAILY_SERVICE_CHARGE)
-
-        self._attr_device_class = SensorDeviceClass.MONETARY
-        self._attr_native_unit_of_measurement = "AUD"
-        self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_icon = "mdi:currency-usd"
-
-    @property
-    def last_reset(self) -> datetime | None:
-        """Return the start of the represented usageDate so HA statistics don't sum across days."""
-        return self._get_latest_usage_date_reset()
-
-    @property
-    def native_value(self) -> float | None:
-        """Return the daily service charge, GST-inclusive."""
-        return self.coordinator.get_daily_service_charge(self._property_id, self._service_type)
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Return the rate basis and calculation for the daily service charge."""
-        rate = self.coordinator._find_service_charge_rate(self._property_id, self._service_type)
-        if rate is None:
-            return None
-
-        rate_incl_gst = rate.get("rate_incl_gst_dollars")
-        rate_excl_gst_cents = rate.get("rate_excl_gst_cents")
-        rate_excl_gst = round(rate_excl_gst_cents / 100, 5) if rate_excl_gst_cents is not None else None
-
-        return {
-            "usage_date": self.coordinator.get_latest_usage_date(self._property_id, self._service_type),
-            "service_rate_incl_gst": rate_incl_gst,
-            "service_rate_excl_gst": rate_excl_gst,
-            "represented_day_count": 1,
-            "calculation": "service_rate_incl_gst × 1 day",
-        }
 
 
 class RedEnergyBillingPeriodServiceChargeSensor(RedEnergyBaseSensor):

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -959,10 +959,7 @@ class RedEnergyBillingPeriodServiceChargeSensor(RedEnergyBaseSensor):
     @property
     def last_reset(self) -> datetime | None:
         """Return the billing period start date so HA statistics reset correctly."""
-        start_date = self._billing_period_start_date()
-        if start_date is None:
-            return None
-        return dt_util.as_utc(start_date)
+        return self._get_last_bill_reset()
 
     @property
     def native_value(self) -> float | None:

--- a/docs/superpowers/plans/2026-08-04-service-charge-sensors.md
+++ b/docs/superpowers/plans/2026-08-04-service-charge-sensors.md
@@ -1,0 +1,995 @@
+# Service Charge Sensors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two new advanced sensors — Daily Service Charge and Billing Period Service Charge — that turn the account's existing `AUD/day` supply-charge rate into directly usable monetary totals for the latest completed day and the current billing period.
+
+**Architecture:** Two new coordinator methods (`get_daily_service_charge`, `get_billing_period_service_charge`) plus a shared rate-lookup helper (`_find_service_charge_rate`) and a shared billing-period-start helper (`_get_billing_period_start`, factored out of the existing `_get_usage_period_dates`) live in `coordinator.py`. Two new thin sensor classes in `sensor.py` read those coordinator methods, following the exact pattern of the existing `RedEnergyTotalImportCostSensor` / `RedEnergyDailyImportCostSensor`. Both sensors are added to the advanced-sensors block in `async_setup_entry`, for both electricity and gas.
+
+**Tech Stack:** Python 3.13/3.14, Home Assistant `DataUpdateCoordinator`/`SensorEntity`, pytest + pytest-asyncio.
+
+## Global Constraints
+
+- Never use real personal data anywhere (code, tests, fixtures, commits) — use fake account numbers / dates like the existing fixtures already do.
+- Follow semantic commit prefixes (`feat:`, `fix:`, `chore:`, `docs:`, `test:`); no test-plan mentions, no Claude/AI attribution, in commit messages.
+- Every new/changed sensor behavior needs a corresponding test — this repo's convention (see `CLAUDE.md`: "When adding sensors, update both `sensor.py` and the corresponding sensor tests").
+- Rate selection: a service-charge rate is one where `rate.get("type") == "SC"` **and** `rate.get("unit") == "day"` — both conditions required. Zero matches → sensors unavailable (`None`). Multiple matches → use the first in list order, ignore the rest.
+- Billing-period day count uses `latest_usage_date` (via `get_latest_usage_date`) as the end boundary, **not** `datetime.now()`. If `latest_usage_date` is `None`, or the computed end is before the billing period start, the billing-period sensor reports `None`.
+- Billing period start reuses the existing `lastBillDate + 1` / 30-day-fallback logic (already implemented in `_get_usage_period_dates`) via a new shared helper — do not duplicate that logic.
+- Excl-GST dollar values are computed as `round(rate_excl_gst_cents / 100, 5)`, matching `data_validation.validate_rates()`'s existing `rate_incl_gst_dollars` rounding convention. No additional rounding is applied when multiplying by day count.
+- Both new sensors are **advanced sensors** (created only when `CONF_ENABLE_ADVANCED_SENSORS` is enabled), for **both** electricity and gas — neither is `_electricity_only`.
+- Both sensors: `device_class = SensorDeviceClass.MONETARY`, `native_unit_of_measurement = "AUD"`, `state_class = SensorStateClass.TOTAL`.
+
+---
+
+## File Structure
+
+- **Modify:** `custom_components/red_energy/coordinator.py` — add `_find_service_charge_rate`, `_get_billing_period_start` (extracted from `_get_usage_period_dates`), `get_daily_service_charge`, `get_billing_period_service_charge`.
+- **Modify:** `custom_components/red_energy/const.py` — add `SENSOR_TYPE_DAILY_SERVICE_CHARGE`, `SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE`.
+- **Modify:** `custom_components/red_energy/sensor.py` — add `RedEnergyDailyServiceChargeSensor`, `RedEnergyBillingPeriodServiceChargeSensor` classes; wire both into the advanced-sensors block of `async_setup_entry`; add import lines.
+- **Create:** `tests/test_service_charge_sensors.py` — coordinator method tests + sensor tests, following the fixture conventions of `tests/test_issue_62_fixes.py` (usage/date shape) and `tests/test_sensor_rates.py` (rates/metadata shape).
+
+---
+
+### Task 1: Extract `_get_billing_period_start` helper in coordinator.py
+
+**Files:**
+- Modify: `custom_components/red_energy/coordinator.py:74-108` (`_get_usage_period_dates`)
+- Test: `tests/test_issue_62_fixes.py` (existing `TestBillingPeriodBoundary` tests must still pass unchanged — this task must not change `_get_usage_period_dates` behavior)
+
+**Interfaces:**
+- Produces: `RedEnergyDataCoordinator._get_billing_period_start(self, service: dict[str, Any]) -> datetime` — returns the resolved billing period start (a `datetime`, midnight-naive, same as today's `start_date`), applying the `lastBillDate + 1` / 30-day-fallback logic. Takes no `end_date` parameter; the 30-day fallback and the "in the future" / ">90 days old" warnings are computed relative to `datetime.now()` internally, exactly as today.
+
+- [ ] **Step 1: Write the failing test — confirm current behavior is preserved via the helper**
+
+Add to `tests/test_issue_62_fixes.py`, inside `class TestBillingPeriodBoundary`:
+
+```python
+    def test_get_billing_period_start_matches_get_usage_period_dates(self, coordinator):
+        last_bill_date = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%d")
+        service = {"lastBillDate": last_bill_date}
+
+        start_from_helper = coordinator._get_billing_period_start(service)
+        start_from_period_dates, _ = coordinator._get_usage_period_dates(service)
+
+        assert start_from_helper.date() == start_from_period_dates.date()
+
+    def test_get_billing_period_start_falls_back_to_30_days_when_missing(self, coordinator):
+        start = coordinator._get_billing_period_start({})
+        assert (datetime.now() - start).days == 30
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_issue_62_fixes.py -k "billing_period_start" -v`
+Expected: FAIL with `AttributeError: 'RedEnergyDataCoordinator' object has no attribute '_get_billing_period_start'`
+
+- [ ] **Step 3: Extract the helper**
+
+In `custom_components/red_energy/coordinator.py`, replace the body of `_get_usage_period_dates` (lines 74-108) with:
+
+```python
+    def _get_billing_period_start(self, service: dict[str, Any]) -> datetime:
+        """Resolve the current billing period's start date.
+
+        lastBillDate is the final day of the *previous* billing period, so
+        the new period's usage starts the following day - otherwise that
+        day's usage/cost is double-counted across both periods. Falls back
+        to a 30-day window when lastBillDate is missing, invalid, in the
+        future, or implausibly old (>90 days).
+        """
+        end_date = datetime.now()
+        start_date = None
+
+        last_bill_date = service.get("lastBillDate")
+        if last_bill_date:
+            try:
+                start_date = datetime.strptime(last_bill_date, "%Y-%m-%d") + timedelta(days=1)
+
+                if start_date > end_date:
+                    _LOGGER.warning("lastBillDate %s is in the future, falling back to 30-day period", last_bill_date)
+                    start_date = None
+                elif (end_date - start_date).days > 90:
+                    _LOGGER.warning("lastBillDate %s is >90 days old (%d days), this may be a long billing period",
+                                  last_bill_date, (end_date - start_date).days)
+                else:
+                    _LOGGER.info("Using billing period: %s to %s (%d days)",
+                               start_date.strftime('%Y-%m-%d'),
+                               end_date.strftime('%Y-%m-%d'),
+                               (end_date - start_date).days)
+
+            except (ValueError, TypeError) as err:
+                _LOGGER.warning("Invalid lastBillDate format '%s': %s, falling back to 30-day period", last_bill_date, err)
+                start_date = None
+
+        if start_date is None:
+            start_date = end_date - timedelta(days=30)
+            _LOGGER.info("Using 30-day fallback period: %s to %s",
+                       start_date.strftime('%Y-%m-%d'),
+                       end_date.strftime('%Y-%m-%d'))
+
+        return start_date
+
+    def _get_usage_period_dates(self, service: dict[str, Any]) -> tuple[datetime, datetime]:
+        end_date = datetime.now()
+        start_date = self._get_billing_period_start(service)
+        return start_date, end_date
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_issue_62_fixes.py -k "TestBillingPeriodBoundary" -v`
+Expected: PASS (all 4 tests: the 2 existing plus the 2 new ones)
+
+- [ ] **Step 5: Run the full existing suite to confirm no regressions**
+
+Run: `pytest tests/ -v`
+Expected: PASS (same pass count as before this change, plus the 2 new tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/red_energy/coordinator.py tests/test_issue_62_fixes.py
+git commit -m "refactor: extract billing period start into shared coordinator helper"
+```
+
+---
+
+### Task 2: Add `_find_service_charge_rate` and `get_daily_service_charge` to coordinator.py
+
+**Files:**
+- Modify: `custom_components/red_energy/coordinator.py` — add methods after `get_service_rates` (currently at line 600-606)
+- Test: `tests/test_service_charge_sensors.py` (new file)
+
+**Interfaces:**
+- Consumes: `self.get_service_rates(property_id, service_type) -> list[dict]` (existing, coordinator.py:600)
+- Produces:
+  - `RedEnergyDataCoordinator._find_service_charge_rate(self, property_id: str, service_type: str) -> dict[str, Any] | None`
+  - `RedEnergyDataCoordinator.get_daily_service_charge(self, property_id: str, service_type: str) -> float | None`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_service_charge_sensors.py`:
+
+```python
+"""Tests for Daily Service Charge and Billing Period Service Charge sensors (issue #71)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.red_energy.coordinator import RedEnergyDataCoordinator
+from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY
+from custom_components.red_energy.sensor import (
+    RedEnergyDailyServiceChargeSensor,
+    RedEnergyBillingPeriodServiceChargeSensor,
+)
+
+SUPPLY_CHARGE_RATE = {
+    "rate_code": "80008279798S",
+    "rate_desc": "Daily Supply Charge",
+    "rate_incl_gst_dollars": 1.78145,
+    "type": "SC",
+    "rate_excl_gst_cents": 161.95,
+    "discounted_rate_excl_gst_in_cents": 161.95,
+    "discounted_rate_incl_gst_in_cents": 178.145,
+    "unit": "day",
+    "unit_step_desc": None,
+}
+
+ENERGY_RATE = {
+    "rate_code": "80008279798P",
+    "rate_desc": "Peak",
+    "rate_incl_gst_dollars": 0.27005,
+    "type": "PR",
+    "rate_excl_gst_cents": 24.55,
+    "discounted_rate_excl_gst_in_cents": 24.55,
+    "discounted_rate_incl_gst_in_cents": 27.005,
+    "unit": "kWh",
+    "unit_step_desc": None,
+}
+
+SECOND_SUPPLY_CHARGE_RATE = {
+    "rate_code": "80008279798S2",
+    "rate_desc": "Second Daily Supply Charge",
+    "rate_incl_gst_dollars": 0.5,
+    "type": "SC",
+    "rate_excl_gst_cents": 45.45,
+    "discounted_rate_excl_gst_in_cents": 45.45,
+    "discounted_rate_incl_gst_in_cents": 50.0,
+    "unit": "day",
+    "unit_step_desc": None,
+}
+
+
+@pytest.fixture
+def mock_hass():
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock()
+    return hass
+
+
+@pytest.fixture
+def coordinator(mock_hass):
+    with patch(
+        "custom_components.red_energy.coordinator.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        coord = RedEnergyDataCoordinator(
+            hass=mock_hass,
+            username="test_user",
+            password="test_pass",
+            selected_accounts=["2000002"],
+            services=["electricity"],
+        )
+    coord.api = AsyncMock()
+    coord.api._access_token = "test_token"
+    return coord
+
+
+def _set_coordinator_data(coordinator, rates, usage_entries=None, last_bill_date=None):
+    """Build coordinator.data with both the property.services (metadata/rates)
+    and top-level services (usage) shapes get_service_metadata/get_service_usage expect."""
+    service_metadata = {
+        "type": SERVICE_TYPE_ELECTRICITY,
+        "consumer_number": "elec-1",
+        "meterType": "INTERVAL",
+        "rates": rates,
+    }
+    if last_bill_date is not None:
+        service_metadata["lastBillDate"] = last_bill_date
+
+    services_usage = {}
+    if usage_entries is not None:
+        services_usage[SERVICE_TYPE_ELECTRICITY] = {
+            "consumer_number": "elec-1",
+            "last_updated": "2024-01-30T10:00:00",
+            "usage_data": {
+                "from_date": "2024-01-01",
+                "to_date": "2024-01-30",
+                "usage_data": usage_entries,
+            },
+        }
+
+    coordinator.data = {
+        "usage_data": {
+            "2000002": {
+                "property": {
+                    "name": "Test property",
+                    "address": {},
+                    "services": [service_metadata],
+                },
+                "services": services_usage,
+            },
+        }
+    }
+
+
+class TestFindServiceChargeRate:
+    def test_returns_none_when_no_rates(self, coordinator):
+        _set_coordinator_data(coordinator, [])
+        assert coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_returns_none_when_no_sc_day_rate(self, coordinator):
+        _set_coordinator_data(coordinator, [ENERGY_RATE])
+        assert coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_finds_the_sc_day_rate_among_others(self, coordinator):
+        _set_coordinator_data(coordinator, [ENERGY_RATE, SUPPLY_CHARGE_RATE])
+        result = coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result == SUPPLY_CHARGE_RATE
+
+    def test_uses_first_match_when_multiple_sc_day_rates(self, coordinator):
+        _set_coordinator_data(coordinator, [SUPPLY_CHARGE_RATE, SECOND_SUPPLY_CHARGE_RATE])
+        result = coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result == SUPPLY_CHARGE_RATE
+
+    def test_type_sc_without_day_unit_does_not_match(self, coordinator):
+        rate = {**SUPPLY_CHARGE_RATE, "unit": "kWh"}
+        _set_coordinator_data(coordinator, [rate])
+        assert coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_day_unit_without_type_sc_does_not_match(self, coordinator):
+        rate = {**SUPPLY_CHARGE_RATE, "type": "PR"}
+        _set_coordinator_data(coordinator, [rate])
+        assert coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+
+class TestGetDailyServiceCharge:
+    def test_returns_rate_incl_gst_dollars(self, coordinator):
+        _set_coordinator_data(coordinator, [SUPPLY_CHARGE_RATE])
+        assert coordinator.get_daily_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) == pytest.approx(1.78145)
+
+    def test_returns_none_when_no_matching_rate(self, coordinator):
+        _set_coordinator_data(coordinator, [ENERGY_RATE])
+        assert coordinator.get_daily_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_service_charge_sensors.py -k "TestFindServiceChargeRate or TestGetDailyServiceCharge" -v`
+Expected: FAIL with `AttributeError: 'RedEnergyDataCoordinator' object has no attribute '_find_service_charge_rate'` (the `RedEnergyDailyServiceChargeSensor`/`RedEnergyBillingPeriodServiceChargeSensor` import at the top of the file will also fail at collection time — that's expected and resolved in Task 4)
+
+For this step only, temporarily comment out the `from custom_components.red_energy.sensor import (...)` block at the top of the test file (both sensor names) so the coordinator tests can run in isolation; restore it in Task 4 Step 1.
+
+- [ ] **Step 3: Implement `_find_service_charge_rate` and `get_daily_service_charge`**
+
+In `custom_components/red_energy/coordinator.py`, add immediately after `get_service_rates` (after line 606):
+
+```python
+    def _find_service_charge_rate(self, property_id: str, service_type: str) -> dict[str, Any] | None:
+        """Find the daily service/supply charge rate for a property and service.
+
+        Identified by type == "SC" and unit == "day" together - neither
+        field alone reliably distinguishes the service charge from other
+        rates on the same plan. If more than one rate matches, the first
+        in list order is used.
+        """
+        rates = self.get_service_rates(property_id, service_type)
+        return next(
+            (r for r in rates if r.get("type") == "SC" and r.get("unit") == "day"),
+            None,
+        )
+
+    def get_daily_service_charge(self, property_id: str, service_type: str) -> float | None:
+        """Get the daily service/supply charge amount, GST-inclusive."""
+        rate = self._find_service_charge_rate(property_id, service_type)
+        return rate.get("rate_incl_gst_dollars") if rate else None
+```
+
+- [ ] **Step 4: Restore the sensor import and re-run (will still fail at collection - expected until Task 4)**
+
+Leave the sensor import commented out for now; run only the coordinator-focused tests:
+
+Run: `pytest tests/test_service_charge_sensors.py -k "TestFindServiceChargeRate or TestGetDailyServiceCharge" -v`
+Expected: PASS (10 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/red_energy/coordinator.py tests/test_service_charge_sensors.py
+git commit -m "feat: add service charge rate lookup to coordinator"
+```
+
+---
+
+### Task 3: Add `get_billing_period_service_charge` to coordinator.py
+
+**Files:**
+- Modify: `custom_components/red_energy/coordinator.py` — add method after `get_daily_service_charge`
+- Test: `tests/test_service_charge_sensors.py`
+
+**Interfaces:**
+- Consumes:
+  - `self._find_service_charge_rate(property_id, service_type) -> dict | None` (Task 2)
+  - `self.get_latest_usage_date(property_id, service_type) -> str | None` (existing, coordinator.py:716)
+  - `self.get_service_metadata(property_id, service_type) -> dict | None` (existing, coordinator.py:584)
+  - `self._get_billing_period_start(service: dict) -> datetime` (Task 1)
+- Produces: `RedEnergyDataCoordinator.get_billing_period_service_charge(self, property_id: str, service_type: str) -> float | None`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_service_charge_sensors.py`:
+
+```python
+class TestGetBillingPeriodServiceCharge:
+    def test_seven_day_period_matches_issue_example(self, coordinator):
+        last_bill_date = "2025-07-25"
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            last_bill_date=last_bill_date,
+        )
+        result = coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result == pytest.approx(7 * 1.78145)
+
+    def test_returns_none_when_no_matching_rate(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [ENERGY_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        assert coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_returns_none_when_no_usage_data(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[],
+            last_bill_date="2025-07-25",
+        )
+        assert coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_returns_none_when_latest_usage_date_before_period_start(self, coordinator):
+        """Stale/cached usage predating a just-rolled billing period must not produce a negative day count."""
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-07-20", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        assert coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_falls_back_to_30_day_period_when_last_bill_date_missing(self, coordinator):
+        today = datetime.now()
+        latest_usage_date = today.strftime("%Y-%m-%d")
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": latest_usage_date, "import_usage": 10.0}],
+            last_bill_date=None,
+        )
+        result = coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        expected_days = (today.date() - (today - timedelta(days=30)).date()).days + 1
+        assert result == pytest.approx(expected_days * 1.78145)
+
+    def test_single_day_period_counts_as_one_day(self, coordinator):
+        """lastBillDate + 1 == latest usageDate must count as exactly 1 day, not 0."""
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-07-26", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        result = coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result == pytest.approx(1 * 1.78145)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_service_charge_sensors.py -k "TestGetBillingPeriodServiceCharge" -v`
+Expected: FAIL with `AttributeError: 'RedEnergyDataCoordinator' object has no attribute 'get_billing_period_service_charge'`
+
+- [ ] **Step 3: Implement `get_billing_period_service_charge`**
+
+In `custom_components/red_energy/coordinator.py`, add immediately after `get_daily_service_charge`:
+
+```python
+    def get_billing_period_service_charge(self, property_id: str, service_type: str) -> float | None:
+        """Get the accumulated service charge from the billing period start
+        through the latest completed usageDate, inclusive.
+
+        Uses the latest completed usageDate as the period end - not
+        datetime.now() - so a day with no confirmed usage data yet is
+        never counted as a represented day.
+        """
+        rate = self._find_service_charge_rate(property_id, service_type)
+        if rate is None:
+            return None
+
+        latest_usage_date_str = self.get_latest_usage_date(property_id, service_type)
+        if not latest_usage_date_str:
+            return None
+
+        try:
+            billing_period_end = datetime.strptime(latest_usage_date_str, "%Y-%m-%d").date()
+        except (ValueError, TypeError):
+            return None
+
+        service_metadata = self.get_service_metadata(property_id, service_type) or {}
+        billing_period_start = self._get_billing_period_start(service_metadata).date()
+
+        if billing_period_end < billing_period_start:
+            return None
+
+        represented_day_count = (billing_period_end - billing_period_start).days + 1
+        return rate["rate_incl_gst_dollars"] * represented_day_count
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_service_charge_sensors.py -k "TestGetBillingPeriodServiceCharge" -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 5: Run full coordinator-related suite for regressions**
+
+Run: `pytest tests/test_issue_62_fixes.py tests/test_service_charge_sensors.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/red_energy/coordinator.py tests/test_service_charge_sensors.py
+git commit -m "feat: add billing period service charge calculation to coordinator"
+```
+
+---
+
+### Task 4: Add sensor type constants and sensor classes to sensor.py
+
+**Files:**
+- Modify: `custom_components/red_energy/const.py` — add 2 new constants after line 92 (`SENSOR_TYPE_RATE_PREFIX`)
+- Modify: `custom_components/red_energy/sensor.py` — add imports, 2 new sensor classes, wire into `async_setup_entry`
+- Test: `tests/test_service_charge_sensors.py` (restore the sensor import, add sensor-level tests)
+
+**Interfaces:**
+- Consumes:
+  - `coordinator.get_daily_service_charge(property_id, service_type) -> float | None` (Task 2)
+  - `coordinator.get_billing_period_service_charge(property_id, service_type) -> float | None` (Task 3)
+  - `coordinator._find_service_charge_rate(property_id, service_type) -> dict | None` (Task 2, used directly by sensors for excl-GST/day-count attributes)
+  - `coordinator.get_latest_usage_date(property_id, service_type) -> str | None` (existing)
+  - `coordinator.get_service_metadata(property_id, service_type) -> dict | None` (existing)
+  - `RedEnergyBaseSensor._get_latest_usage_date_reset(self) -> datetime | None` (existing, sensor.py:326)
+- Produces:
+  - `RedEnergyDailyServiceChargeSensor(coordinator, config_entry, property_id, service_type)` class
+  - `RedEnergyBillingPeriodServiceChargeSensor(coordinator, config_entry, property_id, service_type)` class
+
+- [ ] **Step 1: Add sensor type constants**
+
+In `custom_components/red_energy/const.py`, immediately after `SENSOR_TYPE_RATE_PREFIX: Final = "rate"` (line 92), add:
+
+```python
+SENSOR_TYPE_DAILY_SERVICE_CHARGE: Final = "daily_service_charge"
+SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE: Final = "billing_period_service_charge"
+```
+
+- [ ] **Step 2: Restore and extend the test file's sensor import and write failing sensor tests**
+
+In `tests/test_service_charge_sensors.py`, restore the import at the top (undo the Task 2 Step 2 comment-out):
+
+```python
+from custom_components.red_energy.sensor import (
+    RedEnergyDailyServiceChargeSensor,
+    RedEnergyBillingPeriodServiceChargeSensor,
+)
+```
+
+Add at the end of the file:
+
+```python
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+
+def _config_entry():
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    return entry
+
+
+class TestDailyServiceChargeSensor:
+    def test_native_value_and_metadata(self, coordinator):
+        _set_coordinator_data(coordinator, [SUPPLY_CHARGE_RATE])
+        sensor = RedEnergyDailyServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.native_value == pytest.approx(1.78145)
+        assert sensor.device_class == SensorDeviceClass.MONETARY
+        assert sensor.native_unit_of_measurement == "AUD"
+        assert sensor.state_class == SensorStateClass.TOTAL
+
+    def test_native_value_none_when_no_rate(self, coordinator):
+        _set_coordinator_data(coordinator, [ENERGY_RATE])
+        sensor = RedEnergyDailyServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes is None
+
+    def test_attributes(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+        )
+        sensor = RedEnergyDailyServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["usage_date"] == "2025-08-01"
+        assert attrs["service_rate_incl_gst"] == pytest.approx(1.78145)
+        assert attrs["service_rate_excl_gst"] == pytest.approx(1.6195)
+        assert attrs["represented_day_count"] == 1
+        assert "calculation" in attrs
+
+    def test_last_reset_is_latest_usage_date(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+        )
+        sensor = RedEnergyDailyServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.last_reset.date().isoformat() == "2025-08-01"
+
+
+class TestBillingPeriodServiceChargeSensor:
+    def test_native_value_and_attributes(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        sensor = RedEnergyBillingPeriodServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.native_value == pytest.approx(7 * 1.78145)
+        assert sensor.device_class == SensorDeviceClass.MONETARY
+        assert sensor.native_unit_of_measurement == "AUD"
+        assert sensor.state_class == SensorStateClass.TOTAL
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["billing_period_start"] == "2025-07-26"
+        assert attrs["billing_period_end"] == "2025-08-01"
+        assert attrs["latest_usage_date"] == "2025-08-01"
+        assert attrs["represented_day_count"] == 7
+        assert attrs["service_rate_incl_gst"] == pytest.approx(1.78145)
+        assert attrs["service_rate_excl_gst"] == pytest.approx(1.6195)
+        assert "calculation" in attrs
+
+    def test_native_value_none_when_no_rate(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [ENERGY_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        sensor = RedEnergyBillingPeriodServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes is None
+
+    def test_last_reset_is_billing_period_start(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        sensor = RedEnergyBillingPeriodServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.last_reset.date().isoformat() == "2025-07-26"
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `pytest tests/test_service_charge_sensors.py -k "SensorTest or SensorSensor or DailyServiceChargeSensor or BillingPeriodServiceChargeSensor" -v`
+Expected: FAIL with `ImportError: cannot import name 'RedEnergyDailyServiceChargeSensor'`
+
+- [ ] **Step 4: Add imports in sensor.py**
+
+In `custom_components/red_energy/sensor.py`, in the `from .const import (...)` block (lines 23-54), add these two lines in alphabetical position (after `SENSOR_TYPE_BILLING_FREQUENCY`, before `SENSOR_TYPE_CHARGE_CLASS`):
+
+```python
+    SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE,
+```
+
+and after `SENSOR_TYPE_DAILY_AVERAGE` (before `SENSOR_TYPE_DISTRIBUTOR`):
+
+```python
+    SENSOR_TYPE_DAILY_SERVICE_CHARGE,
+```
+
+- [ ] **Step 5: Implement the two sensor classes**
+
+In `custom_components/red_energy/sensor.py`, add immediately after the `RedEnergyRateSensor` class (after line 868, before `class RedEnergyAddressSensor`):
+
+```python
+class RedEnergyDailyServiceChargeSensor(RedEnergyBaseSensor):
+    """Red Energy daily service/supply charge sensor.
+
+    Represents the service charge for the latest completed usageDate,
+    derived from the plan's daily supply-charge rate (type "SC", unit
+    "day"). Unavailable when the plan has no such rate.
+    """
+
+    def __init__(
+        self,
+        coordinator: RedEnergyDataCoordinator,
+        config_entry: ConfigEntry,
+        property_id: str,
+        service_type: str,
+    ) -> None:
+        """Initialize the daily service charge sensor."""
+        super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_DAILY_SERVICE_CHARGE)
+
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_native_unit_of_measurement = "AUD"
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_icon = "mdi:currency-usd"
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the start of the represented usageDate so HA statistics don't sum across days."""
+        return self._get_latest_usage_date_reset()
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the daily service charge, GST-inclusive."""
+        return self.coordinator.get_daily_service_charge(self._property_id, self._service_type)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return the rate basis and calculation for the daily service charge."""
+        rate = self.coordinator._find_service_charge_rate(self._property_id, self._service_type)
+        if rate is None:
+            return None
+
+        rate_incl_gst = rate.get("rate_incl_gst_dollars")
+        rate_excl_gst_cents = rate.get("rate_excl_gst_cents")
+        rate_excl_gst = round(rate_excl_gst_cents / 100, 5) if rate_excl_gst_cents is not None else None
+
+        return {
+            "usage_date": self.coordinator.get_latest_usage_date(self._property_id, self._service_type),
+            "service_rate_incl_gst": rate_incl_gst,
+            "service_rate_excl_gst": rate_excl_gst,
+            "represented_day_count": 1,
+            "calculation": "service_rate_incl_gst × 1 day",
+        }
+
+
+class RedEnergyBillingPeriodServiceChargeSensor(RedEnergyBaseSensor):
+    """Red Energy billing period service/supply charge sensor.
+
+    Represents the accumulated service charge from the start of the
+    current billing period through the latest completed usageDate,
+    inclusive. Unavailable when the plan has no daily supply-charge
+    rate, or when the represented day count cannot be determined.
+    """
+
+    def __init__(
+        self,
+        coordinator: RedEnergyDataCoordinator,
+        config_entry: ConfigEntry,
+        property_id: str,
+        service_type: str,
+    ) -> None:
+        """Initialize the billing period service charge sensor."""
+        super().__init__(
+            coordinator, config_entry, property_id, service_type, SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE
+        )
+
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_native_unit_of_measurement = "AUD"
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_icon = "mdi:currency-usd"
+
+    def _billing_period_start_date(self) -> datetime | None:
+        service_metadata = self.coordinator.get_service_metadata(self._property_id, self._service_type) or {}
+        return self.coordinator._get_billing_period_start(service_metadata)
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the billing period start date so HA statistics reset correctly."""
+        start_date = self._billing_period_start_date()
+        if start_date is None:
+            return None
+        return dt_util.as_utc(start_date)
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the accumulated billing period service charge, GST-inclusive."""
+        return self.coordinator.get_billing_period_service_charge(self._property_id, self._service_type)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return the rate basis, day count, and calculation for the billing period service charge."""
+        if self.native_value is None:
+            return None
+
+        rate = self.coordinator._find_service_charge_rate(self._property_id, self._service_type)
+        latest_usage_date = self.coordinator.get_latest_usage_date(self._property_id, self._service_type)
+        billing_period_start = self._billing_period_start_date()
+
+        rate_incl_gst = rate.get("rate_incl_gst_dollars") if rate else None
+        rate_excl_gst_cents = rate.get("rate_excl_gst_cents") if rate else None
+        rate_excl_gst = round(rate_excl_gst_cents / 100, 5) if rate_excl_gst_cents is not None else None
+
+        represented_day_count = None
+        if billing_period_start is not None and latest_usage_date:
+            end_date = datetime.strptime(latest_usage_date, "%Y-%m-%d").date()
+            represented_day_count = (end_date - billing_period_start.date()).days + 1
+
+        return {
+            "billing_period_start": billing_period_start.strftime("%Y-%m-%d") if billing_period_start else None,
+            "billing_period_end": latest_usage_date,
+            "latest_usage_date": latest_usage_date,
+            "represented_day_count": represented_day_count,
+            "service_rate_incl_gst": rate_incl_gst,
+            "service_rate_excl_gst": rate_excl_gst,
+            "calculation": f"service_rate_incl_gst × {represented_day_count} days",
+        }
+
+
+```
+
+- [ ] **Step 6: Wire both sensors into the advanced-sensors block**
+
+In `custom_components/red_energy/sensor.py`, inside `async_setup_entry`, in the `if advanced_sensors_enabled:` block (around line 143-162), add to the list:
+
+```python
+                    RedEnergyCarbonEmissionSensor(coordinator, config_entry, account_id, service_type),
+                    # NEW: Service/supply charge sensors
+                    RedEnergyDailyServiceChargeSensor(coordinator, config_entry, account_id, service_type),
+                    RedEnergyBillingPeriodServiceChargeSensor(coordinator, config_entry, account_id, service_type),
+                ])
+```
+
+(i.e. insert the two new lines directly before the closing `])` of that list, right after the existing `RedEnergyCarbonEmissionSensor` line.)
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pytest tests/test_service_charge_sensors.py -v`
+Expected: PASS (all tests in the file)
+
+- [ ] **Step 8: Run the full test suite for regressions**
+
+Run: `pytest tests/ -v`
+Expected: PASS (all tests, previous count + all new tests added in this plan)
+
+- [ ] **Step 9: Run flake8 and mypy**
+
+Run: `flake8 custom_components --count --select=E9,F63,F7,F82 --show-source --statistics`
+Expected: 0 errors
+
+Run: `mypy custom_components/red_energy --ignore-missing-imports`
+Expected: no new errors introduced by the changed files (pre-existing errors elsewhere are not this task's concern)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add custom_components/red_energy/const.py custom_components/red_energy/sensor.py tests/test_service_charge_sensors.py
+git commit -m "feat: add daily and billing period service charge sensors (#71)"
+```
+
+---
+
+### Task 5: Verify entity setup test coverage for advanced-sensor gating
+
+**Files:**
+- Test: `tests/test_service_charge_sensors.py` (add `async_setup_entry`-level tests, following `tests/test_sensor_rates.py`'s `_coordinator()` mock pattern)
+
+**Interfaces:**
+- Consumes: `async_setup_entry(hass, config_entry, async_add_entities)` (existing, sensor.py:64)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_service_charge_sensors.py`:
+
+```python
+from custom_components.red_energy.const import DOMAIN
+from custom_components.red_energy.sensor import async_setup_entry
+
+
+def _mock_coordinator_for_setup(rates, service_type=SERVICE_TYPE_ELECTRICITY, property_id="2000002"):
+    coordinator = MagicMock()
+    service_metadata = {
+        "type": service_type,
+        "consumer_number": "elec-1",
+        "meterType": "INTERVAL",
+        "rates": rates,
+    }
+    coordinator.data = {
+        "usage_data": {
+            property_id: {
+                "property": {"name": "Test property", "address": {}, "services": [service_metadata]},
+                "services": {},
+            },
+        }
+    }
+    coordinator.last_update_success = True
+    coordinator.get_property_data = MagicMock(
+        side_effect=lambda pid: coordinator.data["usage_data"].get(str(pid))
+    )
+
+    def get_service_metadata(prop_id, svc_type):
+        property_data = coordinator.data["usage_data"].get(str(prop_id))
+        if not property_data:
+            return None
+        services = property_data["property"].get("services", [])
+        return next((s for s in services if s.get("type") == svc_type), None)
+
+    coordinator.get_service_metadata = MagicMock(side_effect=get_service_metadata)
+
+    def get_service_rates(prop_id, svc_type):
+        metadata = get_service_metadata(prop_id, svc_type)
+        return metadata.get("rates", []) if metadata else []
+
+    coordinator.get_service_rates = MagicMock(side_effect=get_service_rates)
+    coordinator.get_service_usage = MagicMock(return_value=None)
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_service_charge_sensors_not_created_when_advanced_disabled():
+    coordinator = _mock_coordinator_for_setup([SUPPLY_CHARGE_RATE])
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["2000002"],
+                "services": [SERVICE_TYPE_ELECTRICITY],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    charge_sensors = [
+        e for e in added_entities
+        if isinstance(e, (RedEnergyDailyServiceChargeSensor, RedEnergyBillingPeriodServiceChargeSensor))
+    ]
+    assert charge_sensors == []
+
+
+@pytest.mark.asyncio
+async def test_service_charge_sensors_created_for_electricity_and_gas_when_advanced_enabled():
+    from custom_components.red_energy.const import CONF_ENABLE_ADVANCED_SENSORS, SERVICE_TYPE_GAS
+
+    coordinator = _mock_coordinator_for_setup([SUPPLY_CHARGE_RATE], service_type=SERVICE_TYPE_ELECTRICITY)
+    gas_coordinator_data = coordinator.data["usage_data"]["2000002"]["property"]["services"]
+    gas_coordinator_data.append({**gas_coordinator_data[0], "type": SERVICE_TYPE_GAS})
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {CONF_ENABLE_ADVANCED_SENSORS: True}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["2000002"],
+                "services": [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    daily_charge_sensors = [e for e in added_entities if isinstance(e, RedEnergyDailyServiceChargeSensor)]
+    billing_charge_sensors = [
+        e for e in added_entities if isinstance(e, RedEnergyBillingPeriodServiceChargeSensor)
+    ]
+    assert len(daily_charge_sensors) == 2
+    assert len(billing_charge_sensors) == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_service_charge_sensors.py -k "async_setup_entry or advanced_disabled or advanced_enabled" -v`
+Expected: FAIL if Task 4 Step 6 was skipped or mis-wired (0 sensors created instead of 2); if Task 4 was completed correctly, this may already PASS - in that case this task documents/locks in the behavior rather than driving it.
+
+- [ ] **Step 3: If failing, fix the wiring in `async_setup_entry`**
+
+Re-check Task 4 Step 6 was applied correctly (both sensor constructors present in the `if advanced_sensors_enabled:` list, correctly indented as part of `service_entities.extend([...])`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_service_charge_sensors.py -v`
+Expected: PASS (all tests in the file)
+
+- [ ] **Step 5: Run the full test suite one final time**
+
+Run: `pytest tests/ -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_service_charge_sensors.py
+git commit -m "test: verify service charge sensor setup gating and multi-service creation"
+```
+
+---
+
+## Post-implementation
+
+- Update the CHANGELOG/release notes per the repo's `creating-pre-releases` skill when ready to cut a release (not part of this plan — a separate step once the branch is reviewed).
+- Manifest version was already bumped to `1.17.0` on this branch prior to this plan's work.

--- a/docs/superpowers/specs/2026-08-04-service-charge-sensors-design.md
+++ b/docs/superpowers/specs/2026-08-04-service-charge-sensors-design.md
@@ -1,0 +1,127 @@
+# Daily & Billing Period Service Charge Sensors (Issue #71)
+
+## Problem
+
+The integration exposes electricity/gas usage costs and export credits, and already exposes the account's daily service/supply rate as a diagnostic `RedEnergyRateSensor` (`AUD/day`). It does not expose the actual dollar service-charge amount for a completed day, or accumulated over the current billing period, so users can't reconcile `usage cost + service charge - export credit` against a Red Energy bill without manually multiplying the rate by the correct day count themselves.
+
+## Goals
+
+- Add a **Daily Service Charge** sensor: the service charge for the latest completed `usageDate` (i.e. the daily SC rate, expressed as a monetary amount for exactly one day).
+- Add a **Billing Period Service Charge** sensor: the accumulated service charge from the start of the current billing period through the latest completed `usageDate`, inclusive.
+- Reuse existing billing-period-start logic (`lastBillDate + 1`, with 30-day fallback) so day counts stay consistent with the rest of the integration's billing-period sensors.
+- Fail closed (report unavailable) whenever required inputs are missing, rather than guessing.
+
+## Non-goals
+
+- No "Estimated Usage and Supply Cost" combined sensor (explicitly deferred by the issue).
+- No support for non-SC charge types (GreenPower, demand charges, etc.) — only the confirmed daily supply/service charge.
+- No historical backdating into HA long-term statistics beyond standard `last_reset` semantics.
+
+## Rate selection
+
+A service charge rate is identified as the entry in `coordinator.get_service_rates(property_id, service_type)` where `rate.get("type") == "SC"` **and** `rate.get("unit") == "day"`. Both conditions must match (not either alone), since `type` and `unit` are independent fields on the payload and neither alone is a reliable-enough signal for "this is the service charge."
+
+- **Zero matches** → both sensors report `native_value = None` (unavailable). This includes gas accounts without a confirmed daily supply charge.
+- **Exactly one match** → used directly.
+- **More than one match** → the first match in the rates list is used; others are ignored. (No real-world account with multiple SC/day rates has been observed; if one surfaces, this is the place to revisit.)
+
+This applies identically to electricity and gas — neither sensor is `_electricity_only`.
+
+## Coordinator changes (`coordinator.py`)
+
+### `_find_service_charge_rate(property_id, service_type) -> dict | None`
+Returns the single matching SC/day rate as described above, or `None`.
+
+### Billing period start — factor out shared helper
+`_get_usage_period_dates()` currently inlines the `lastBillDate + 1` / 30-day-fallback logic to compute a `(start_date, end_date)` tuple for fetching usage data, using `datetime.now()` as `end_date`. Extract the start-date resolution into:
+
+```python
+def _get_billing_period_start(self, service: dict[str, Any]) -> datetime:
+    """Resolve the current billing period's start date (lastBillDate + 1,
+    falling back to a 30-day window when lastBillDate is missing/invalid/
+    in the future/implausibly old)."""
+```
+
+`_get_usage_period_dates()` calls this helper and keeps its own `end_date = datetime.now()` for the usage-fetch window (unchanged behavior). The new service-charge day-count logic below calls the same helper but uses the latest completed `usageDate` as its end boundary instead of `datetime.now()`, since the issue explicitly wants completed days only.
+
+### `get_daily_service_charge(property_id, service_type) -> float | None`
+Returns `rate_incl_gst_dollars` from `_find_service_charge_rate(...)`, or `None` if no rate.
+
+### `get_billing_period_service_charge(property_id, service_type) -> float | None`
+```
+rate = _find_service_charge_rate(property_id, service_type)
+if rate is None: return None
+
+latest_usage_date = get_latest_usage_date(property_id, service_type)  # existing method
+if latest_usage_date is None: return None
+
+service = get_service_metadata(property_id, service_type)
+billing_period_start = _get_billing_period_start(service)
+billing_period_end = parse(latest_usage_date)
+
+if billing_period_end < billing_period_start.date(): return None
+
+represented_day_count = (billing_period_end - billing_period_start.date()).days + 1
+return rate["rate_incl_gst_dollars"] * represented_day_count
+```
+
+`end < start` covers the case where cached/stale usage data predates a just-rolled billing period.
+
+### Excl-GST values
+Computed on demand from the rate dict (not persisted as new coordinator state):
+```python
+service_rate_excl_gst = round(rate["rate_excl_gst_cents"] / 100, 5) if rate.get("rate_excl_gst_cents") is not None else None
+```
+Same rounding convention as `data_validation.validate_rates()`'s `rate_incl_gst_dollars`. Billing-period excl-GST total is `service_rate_excl_gst * represented_day_count` (no additional rounding applied to the multiple).
+
+## Sensor changes (`sensor.py`)
+
+Both sensors: `device_class = MONETARY`, `native_unit_of_measurement = "AUD"`, `state_class = TOTAL`. Added to the **advanced sensors** block in `async_setup_entry` (gated on `CONF_ENABLE_ADVANCED_SENSORS`), for both electricity and gas services — not `_electricity_only`.
+
+### `RedEnergyDailyServiceChargeSensor` (`SENSOR_TYPE_DAILY_SERVICE_CHARGE = "daily_service_charge"`)
+- `native_value`: `coordinator.get_daily_service_charge(...)`
+- `last_reset`: `self._get_latest_usage_date_reset()` (existing helper — start of the represented `usageDate`)
+- `extra_state_attributes`:
+  ```
+  usage_date: coordinator.get_latest_usage_date(...)
+  service_rate_incl_gst: <rate incl GST>
+  service_rate_excl_gst: <rate excl GST>
+  represented_day_count: 1
+  calculation: "service_rate_incl_gst × 1 day"
+  ```
+  Returns `None` when the sensor has no backing rate (mirrors `RedEnergyRateSensor` returning `None` attrs when its rate disappears).
+
+### `RedEnergyBillingPeriodServiceChargeSensor` (`SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE = "billing_period_service_charge"`)
+- `native_value`: `coordinator.get_billing_period_service_charge(...)`
+- `last_reset`: start of the current billing period (new sensor-level helper `_get_billing_period_reset()`, built on the coordinator's `_get_billing_period_start`)
+- `extra_state_attributes`:
+  ```
+  billing_period_start: <date>
+  billing_period_end: <latest usage_date>
+  latest_usage_date: <same as billing_period_end>
+  represented_day_count: <int>
+  service_rate_incl_gst: <rate incl GST>
+  service_rate_excl_gst: <rate excl GST>
+  calculation: "service_rate_incl_gst × represented_day_count days"
+  ```
+  Returns `None` when `native_value` is `None`.
+
+## `const.py`
+Add:
+```python
+SENSOR_TYPE_DAILY_SERVICE_CHARGE: Final = "daily_service_charge"
+SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE: Final = "billing_period_service_charge"
+```
+
+## Testing
+
+- **Coordinator unit tests** (new, alongside existing coordinator test file):
+  - `_find_service_charge_rate`: zero/one/multiple SC-and-day matches; type-only or unit-only matches are correctly excluded.
+  - `get_daily_service_charge`: returns rate or `None`.
+  - `get_billing_period_service_charge`: correct day-count math for a normal case (mirroring the issue's 7-day/$12.47015 example), `lastBillDate` missing → 30-day fallback, `latest_usage_date` missing → `None`, `end < start` → `None`.
+- **Sensor tests** (new, alongside `test_sensor_rates.py` conventions):
+  - `native_value`, `last_reset`, and `extra_state_attributes` for both sensors in the matched-rate and no-rate cases.
+  - Confirm both sensors are only created when `CONF_ENABLE_ADVANCED_SENSORS` is enabled, and are created for both electricity and gas services when a matching rate exists.
+
+## Version bump
+Per repo convention, bump `manifest.json` `version` (MINOR, new feature) as the first commit on the feature branch.

--- a/tests/test_issue_62_fixes.py
+++ b/tests/test_issue_62_fixes.py
@@ -174,6 +174,19 @@ class TestBillingPeriodBoundary:
         start_date, end_date = coordinator._get_usage_period_dates({})
         assert (end_date - start_date).days == 30
 
+    def test_get_billing_period_start_matches_get_usage_period_dates(self, coordinator):
+        last_bill_date = (datetime.now() - timedelta(days=10)).strftime("%Y-%m-%d")
+        service = {"lastBillDate": last_bill_date}
+
+        start_from_helper = coordinator._get_billing_period_start(service)
+        start_from_period_dates, _ = coordinator._get_usage_period_dates(service)
+
+        assert start_from_helper.date() == start_from_period_dates.date()
+
+    def test_get_billing_period_start_falls_back_to_30_days_when_missing(self, coordinator):
+        start = coordinator._get_billing_period_start({})
+        assert (datetime.now() - start).days == 30
+
 
 class TestLatestDaySelection:
     """Bug #5: latest-day values should be selected by max usageDate, not list position."""

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -323,3 +323,108 @@ class TestBillingPeriodServiceChargeSensor:
             coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
         )
         assert sensor.last_reset.date().isoformat() == "2025-07-26"
+
+
+from custom_components.red_energy.const import DOMAIN, CONF_ENABLE_ADVANCED_SENSORS, SERVICE_TYPE_GAS
+from custom_components.red_energy.sensor import async_setup_entry
+
+
+def _mock_coordinator_for_setup(rates, service_type=SERVICE_TYPE_ELECTRICITY, property_id="2000002"):
+    coordinator = MagicMock()
+    service_metadata = {
+        "type": service_type,
+        "consumer_number": "elec-1",
+        "meterType": "INTERVAL",
+        "rates": rates,
+    }
+    coordinator.data = {
+        "usage_data": {
+            property_id: {
+                "property": {"name": "Test property", "address": {}, "services": [service_metadata]},
+                "services": {},
+            },
+        }
+    }
+    coordinator.last_update_success = True
+    coordinator.get_property_data = MagicMock(
+        side_effect=lambda pid: coordinator.data["usage_data"].get(str(pid))
+    )
+
+    def get_service_metadata(prop_id, svc_type):
+        property_data = coordinator.data["usage_data"].get(str(prop_id))
+        if not property_data:
+            return None
+        services = property_data["property"].get("services", [])
+        return next((s for s in services if s.get("type") == svc_type), None)
+
+    coordinator.get_service_metadata = MagicMock(side_effect=get_service_metadata)
+
+    def get_service_rates(prop_id, svc_type):
+        metadata = get_service_metadata(prop_id, svc_type)
+        return metadata.get("rates", []) if metadata else []
+
+    coordinator.get_service_rates = MagicMock(side_effect=get_service_rates)
+    coordinator.get_service_usage = MagicMock(return_value=None)
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_service_charge_sensors_not_created_when_advanced_disabled():
+    coordinator = _mock_coordinator_for_setup([SUPPLY_CHARGE_RATE])
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["2000002"],
+                "services": [SERVICE_TYPE_ELECTRICITY],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    charge_sensors = [
+        e for e in added_entities
+        if isinstance(e, (RedEnergyDailyServiceChargeSensor, RedEnergyBillingPeriodServiceChargeSensor))
+    ]
+    assert charge_sensors == []
+
+
+@pytest.mark.asyncio
+async def test_service_charge_sensors_created_for_electricity_and_gas_when_advanced_enabled():
+    coordinator = _mock_coordinator_for_setup([SUPPLY_CHARGE_RATE], service_type=SERVICE_TYPE_ELECTRICITY)
+    gas_coordinator_data = coordinator.data["usage_data"]["2000002"]["property"]["services"]
+    gas_coordinator_data.append({**gas_coordinator_data[0], "type": SERVICE_TYPE_GAS})
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {CONF_ENABLE_ADVANCED_SENSORS: True}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["2000002"],
+                "services": [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    daily_charge_sensors = [e for e in added_entities if isinstance(e, RedEnergyDailyServiceChargeSensor)]
+    billing_charge_sensors = [
+        e for e in added_entities if isinstance(e, RedEnergyBillingPeriodServiceChargeSensor)
+    ]
+    assert len(daily_charge_sensors) == 2
+    assert len(billing_charge_sensors) == 2

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -1,4 +1,4 @@
-"""Tests for Daily Service Charge and Billing Period Service Charge sensors (issue #71)."""
+"""Tests for the Billing Period Service Charge sensor (issue #71)."""
 from __future__ import annotations
 
 from datetime import datetime, timedelta
@@ -9,7 +9,6 @@ import pytest
 from custom_components.red_energy.coordinator import RedEnergyDataCoordinator
 from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY
 from custom_components.red_energy.sensor import (
-    RedEnergyDailyServiceChargeSensor,
     RedEnergyBillingPeriodServiceChargeSensor,
 )
 
@@ -143,16 +142,6 @@ class TestFindServiceChargeRate:
         assert coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY) is None
 
 
-class TestGetDailyServiceCharge:
-    def test_returns_rate_incl_gst_dollars(self, coordinator):
-        _set_coordinator_data(coordinator, [SUPPLY_CHARGE_RATE])
-        assert coordinator.get_daily_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) == pytest.approx(1.78145)
-
-    def test_returns_none_when_no_matching_rate(self, coordinator):
-        _set_coordinator_data(coordinator, [ENERGY_RATE])
-        assert coordinator.get_daily_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) is None
-
-
 class TestGetBillingPeriodServiceCharge:
     def test_seven_day_period_matches_issue_example(self, coordinator):
         last_bill_date = "2025-07-25"
@@ -225,53 +214,6 @@ def _config_entry():
     entry = MagicMock()
     entry.entry_id = "entry1"
     return entry
-
-
-class TestDailyServiceChargeSensor:
-    def test_native_value_and_metadata(self, coordinator):
-        _set_coordinator_data(coordinator, [SUPPLY_CHARGE_RATE])
-        sensor = RedEnergyDailyServiceChargeSensor(
-            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
-        )
-        assert sensor.native_value == pytest.approx(1.78145)
-        assert sensor.device_class == SensorDeviceClass.MONETARY
-        assert sensor.native_unit_of_measurement == "AUD"
-        assert sensor.state_class == SensorStateClass.TOTAL
-
-    def test_native_value_none_when_no_rate(self, coordinator):
-        _set_coordinator_data(coordinator, [ENERGY_RATE])
-        sensor = RedEnergyDailyServiceChargeSensor(
-            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
-        )
-        assert sensor.native_value is None
-        assert sensor.extra_state_attributes is None
-
-    def test_attributes(self, coordinator):
-        _set_coordinator_data(
-            coordinator,
-            [SUPPLY_CHARGE_RATE],
-            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
-        )
-        sensor = RedEnergyDailyServiceChargeSensor(
-            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
-        )
-        attrs = sensor.extra_state_attributes
-        assert attrs["usage_date"] == "2025-08-01"
-        assert attrs["service_rate_incl_gst"] == pytest.approx(1.78145)
-        assert attrs["service_rate_excl_gst"] == pytest.approx(1.6195)
-        assert attrs["represented_day_count"] == 1
-        assert "calculation" in attrs
-
-    def test_last_reset_is_latest_usage_date(self, coordinator):
-        _set_coordinator_data(
-            coordinator,
-            [SUPPLY_CHARGE_RATE],
-            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
-        )
-        sensor = RedEnergyDailyServiceChargeSensor(
-            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
-        )
-        assert sensor.last_reset.date().isoformat() == "2025-08-01"
 
 
 class TestBillingPeriodServiceChargeSensor:
@@ -409,7 +351,7 @@ async def test_service_charge_sensors_not_created_when_advanced_disabled():
 
     charge_sensors = [
         e for e in added_entities
-        if isinstance(e, (RedEnergyDailyServiceChargeSensor, RedEnergyBillingPeriodServiceChargeSensor))
+        if isinstance(e, RedEnergyBillingPeriodServiceChargeSensor)
     ]
     assert charge_sensors == []
 
@@ -439,9 +381,7 @@ async def test_service_charge_sensors_created_for_electricity_and_gas_when_advan
     async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
     await async_setup_entry(hass, config_entry, async_add_entities)
 
-    daily_charge_sensors = [e for e in added_entities if isinstance(e, RedEnergyDailyServiceChargeSensor)]
     billing_charge_sensors = [
         e for e in added_entities if isinstance(e, RedEnergyBillingPeriodServiceChargeSensor)
     ]
-    assert len(daily_charge_sensors) == 2
     assert len(billing_charge_sensors) == 2

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -154,3 +154,68 @@ class TestGetDailyServiceCharge:
     def test_returns_none_when_no_matching_rate(self, coordinator):
         _set_coordinator_data(coordinator, [ENERGY_RATE])
         assert coordinator.get_daily_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+
+class TestGetBillingPeriodServiceCharge:
+    def test_seven_day_period_matches_issue_example(self, coordinator):
+        last_bill_date = "2025-07-25"
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            last_bill_date=last_bill_date,
+        )
+        result = coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result == pytest.approx(7 * 1.78145)
+
+    def test_returns_none_when_no_matching_rate(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [ENERGY_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        assert coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_returns_none_when_no_usage_data(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[],
+            last_bill_date="2025-07-25",
+        )
+        assert coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_returns_none_when_latest_usage_date_before_period_start(self, coordinator):
+        """Stale/cached usage predating a just-rolled billing period must not produce a negative day count."""
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-07-20", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        assert coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_falls_back_to_30_day_period_when_last_bill_date_missing(self, coordinator):
+        today = datetime.now()
+        latest_usage_date = today.strftime("%Y-%m-%d")
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": latest_usage_date, "import_usage": 10.0}],
+            last_bill_date=None,
+        )
+        result = coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        expected_days = (today.date() - (today - timedelta(days=30)).date()).days + 1
+        assert result == pytest.approx(expected_days * 1.78145)
+
+    def test_single_day_period_counts_as_one_day(self, coordinator):
+        """lastBillDate + 1 == latest usageDate must count as exactly 1 day, not 0."""
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-07-26", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        result = coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result == pytest.approx(1 * 1.78145)

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -312,7 +312,7 @@ class TestBillingPeriodServiceChargeSensor:
         assert sensor.native_value is None
         assert sensor.extra_state_attributes is None
 
-    def test_last_reset_is_billing_period_start(self, coordinator):
+    def test_last_reset_matches_last_bill_date(self, coordinator):
         _set_coordinator_data(
             coordinator,
             [SUPPLY_CHARGE_RATE],
@@ -322,7 +322,24 @@ class TestBillingPeriodServiceChargeSensor:
         sensor = RedEnergyBillingPeriodServiceChargeSensor(
             coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
         )
-        assert sensor.last_reset.date().isoformat() == "2025-07-26"
+        # last_reset must match the sibling billing-period TOTAL sensors
+        # (_get_last_bill_reset -> raw lastBillDate), not the +1-day
+        # billing_period_start used for the day-count/attribute math.
+        assert sensor.last_reset.date().isoformat() == "2025-07-25"
+
+    def test_last_reset_is_none_when_last_bill_date_missing(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+        )
+        sensor = RedEnergyBillingPeriodServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        # Without lastBillDate, last_reset must be None (stable), not a
+        # datetime.now()-based fallback that drifts on every poll and would
+        # reset HA's statistics accumulation each update.
+        assert sensor.last_reset is None
 
 
 from custom_components.red_energy.const import DOMAIN, CONF_ENABLE_ADVANCED_SENSORS, SERVICE_TYPE_GAS

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -8,13 +8,10 @@ import pytest
 
 from custom_components.red_energy.coordinator import RedEnergyDataCoordinator
 from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY
-
-# TEMPORARY: Commented out pending Task 4 (sensor classes not yet implemented).
-# Restore this import block in Task 4 Step 1.
-# from custom_components.red_energy.sensor import (
-#     RedEnergyDailyServiceChargeSensor,
-#     RedEnergyBillingPeriodServiceChargeSensor,
-# )
+from custom_components.red_energy.sensor import (
+    RedEnergyDailyServiceChargeSensor,
+    RedEnergyBillingPeriodServiceChargeSensor,
+)
 
 SUPPLY_CHARGE_RATE = {
     "rate_code": "80008279798S",
@@ -219,3 +216,110 @@ class TestGetBillingPeriodServiceCharge:
         )
         result = coordinator.get_billing_period_service_charge("2000002", SERVICE_TYPE_ELECTRICITY)
         assert result == pytest.approx(1 * 1.78145)
+
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+
+
+def _config_entry():
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    return entry
+
+
+class TestDailyServiceChargeSensor:
+    def test_native_value_and_metadata(self, coordinator):
+        _set_coordinator_data(coordinator, [SUPPLY_CHARGE_RATE])
+        sensor = RedEnergyDailyServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.native_value == pytest.approx(1.78145)
+        assert sensor.device_class == SensorDeviceClass.MONETARY
+        assert sensor.native_unit_of_measurement == "AUD"
+        assert sensor.state_class == SensorStateClass.TOTAL
+
+    def test_native_value_none_when_no_rate(self, coordinator):
+        _set_coordinator_data(coordinator, [ENERGY_RATE])
+        sensor = RedEnergyDailyServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes is None
+
+    def test_attributes(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+        )
+        sensor = RedEnergyDailyServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        attrs = sensor.extra_state_attributes
+        assert attrs["usage_date"] == "2025-08-01"
+        assert attrs["service_rate_incl_gst"] == pytest.approx(1.78145)
+        assert attrs["service_rate_excl_gst"] == pytest.approx(1.6195)
+        assert attrs["represented_day_count"] == 1
+        assert "calculation" in attrs
+
+    def test_last_reset_is_latest_usage_date(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+        )
+        sensor = RedEnergyDailyServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.last_reset.date().isoformat() == "2025-08-01"
+
+
+class TestBillingPeriodServiceChargeSensor:
+    def test_native_value_and_attributes(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        sensor = RedEnergyBillingPeriodServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.native_value == pytest.approx(7 * 1.78145)
+        assert sensor.device_class == SensorDeviceClass.MONETARY
+        assert sensor.native_unit_of_measurement == "AUD"
+        assert sensor.state_class == SensorStateClass.TOTAL
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["billing_period_start"] == "2025-07-26"
+        assert attrs["billing_period_end"] == "2025-08-01"
+        assert attrs["latest_usage_date"] == "2025-08-01"
+        assert attrs["represented_day_count"] == 7
+        assert attrs["service_rate_incl_gst"] == pytest.approx(1.78145)
+        assert attrs["service_rate_excl_gst"] == pytest.approx(1.6195)
+        assert "calculation" in attrs
+
+    def test_native_value_none_when_no_rate(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [ENERGY_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        sensor = RedEnergyBillingPeriodServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes is None
+
+    def test_last_reset_is_billing_period_start(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [SUPPLY_CHARGE_RATE],
+            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            last_bill_date="2025-07-25",
+        )
+        sensor = RedEnergyBillingPeriodServiceChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.last_reset.date().isoformat() == "2025-07-26"

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -1,0 +1,156 @@
+"""Tests for Daily Service Charge and Billing Period Service Charge sensors (issue #71)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.red_energy.coordinator import RedEnergyDataCoordinator
+from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY
+
+# TEMPORARY: Commented out pending Task 4 (sensor classes not yet implemented).
+# Restore this import block in Task 4 Step 1.
+# from custom_components.red_energy.sensor import (
+#     RedEnergyDailyServiceChargeSensor,
+#     RedEnergyBillingPeriodServiceChargeSensor,
+# )
+
+SUPPLY_CHARGE_RATE = {
+    "rate_code": "80008279798S",
+    "rate_desc": "Daily Supply Charge",
+    "rate_incl_gst_dollars": 1.78145,
+    "type": "SC",
+    "rate_excl_gst_cents": 161.95,
+    "discounted_rate_excl_gst_in_cents": 161.95,
+    "discounted_rate_incl_gst_in_cents": 178.145,
+    "unit": "day",
+    "unit_step_desc": None,
+}
+
+ENERGY_RATE = {
+    "rate_code": "80008279798P",
+    "rate_desc": "Peak",
+    "rate_incl_gst_dollars": 0.27005,
+    "type": "PR",
+    "rate_excl_gst_cents": 24.55,
+    "discounted_rate_excl_gst_in_cents": 24.55,
+    "discounted_rate_incl_gst_in_cents": 27.005,
+    "unit": "kWh",
+    "unit_step_desc": None,
+}
+
+SECOND_SUPPLY_CHARGE_RATE = {
+    "rate_code": "80008279798S2",
+    "rate_desc": "Second Daily Supply Charge",
+    "rate_incl_gst_dollars": 0.5,
+    "type": "SC",
+    "rate_excl_gst_cents": 45.45,
+    "discounted_rate_excl_gst_in_cents": 45.45,
+    "discounted_rate_incl_gst_in_cents": 50.0,
+    "unit": "day",
+    "unit_step_desc": None,
+}
+
+
+@pytest.fixture
+def mock_hass():
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock()
+    return hass
+
+
+@pytest.fixture
+def coordinator(mock_hass):
+    with patch(
+        "custom_components.red_energy.coordinator.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        coord = RedEnergyDataCoordinator(
+            hass=mock_hass,
+            username="test_user",
+            password="test_pass",
+            selected_accounts=["2000002"],
+            services=["electricity"],
+        )
+    coord.api = AsyncMock()
+    coord.api._access_token = "test_token"
+    return coord
+
+
+def _set_coordinator_data(coordinator, rates, usage_entries=None, last_bill_date=None):
+    """Build coordinator.data with both the property.services (metadata/rates)
+    and top-level services (usage) shapes get_service_metadata/get_service_usage expect."""
+    service_metadata = {
+        "type": SERVICE_TYPE_ELECTRICITY,
+        "consumer_number": "elec-1",
+        "meterType": "INTERVAL",
+        "rates": rates,
+    }
+    if last_bill_date is not None:
+        service_metadata["lastBillDate"] = last_bill_date
+
+    services_usage = {}
+    if usage_entries is not None:
+        services_usage[SERVICE_TYPE_ELECTRICITY] = {
+            "consumer_number": "elec-1",
+            "last_updated": "2024-01-30T10:00:00",
+            "usage_data": {
+                "from_date": "2024-01-01",
+                "to_date": "2024-01-30",
+                "usage_data": usage_entries,
+            },
+        }
+
+    coordinator.data = {
+        "usage_data": {
+            "2000002": {
+                "property": {
+                    "name": "Test property",
+                    "address": {},
+                    "services": [service_metadata],
+                },
+                "services": services_usage,
+            },
+        }
+    }
+
+
+class TestFindServiceChargeRate:
+    def test_returns_none_when_no_rates(self, coordinator):
+        _set_coordinator_data(coordinator, [])
+        assert coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_returns_none_when_no_sc_day_rate(self, coordinator):
+        _set_coordinator_data(coordinator, [ENERGY_RATE])
+        assert coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_finds_the_sc_day_rate_among_others(self, coordinator):
+        _set_coordinator_data(coordinator, [ENERGY_RATE, SUPPLY_CHARGE_RATE])
+        result = coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result == SUPPLY_CHARGE_RATE
+
+    def test_uses_first_match_when_multiple_sc_day_rates(self, coordinator):
+        _set_coordinator_data(coordinator, [SUPPLY_CHARGE_RATE, SECOND_SUPPLY_CHARGE_RATE])
+        result = coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result == SUPPLY_CHARGE_RATE
+
+    def test_type_sc_without_day_unit_does_not_match(self, coordinator):
+        rate = {**SUPPLY_CHARGE_RATE, "unit": "kWh"}
+        _set_coordinator_data(coordinator, [rate])
+        assert coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_day_unit_without_type_sc_does_not_match(self, coordinator):
+        rate = {**SUPPLY_CHARGE_RATE, "type": "PR"}
+        _set_coordinator_data(coordinator, [rate])
+        assert coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+
+class TestGetDailyServiceCharge:
+    def test_returns_rate_incl_gst_dollars(self, coordinator):
+        _set_coordinator_data(coordinator, [SUPPLY_CHARGE_RATE])
+        assert coordinator.get_daily_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) == pytest.approx(1.78145)
+
+    def test_returns_none_when_no_matching_rate(self, coordinator):
+        _set_coordinator_data(coordinator, [ENERGY_RATE])
+        assert coordinator.get_daily_service_charge("2000002", SERVICE_TYPE_ELECTRICITY) is None


### PR DESCRIPTION
## Summary
- Add `Billing Period Service Charge` sensor: the accumulated service charge from the billing period start through the latest completed day, inclusive
- Advanced sensor (opt-in), created for electricity and gas alike, and goes unavailable when the plan has no matching `SC`/`day` rate
- No separate "Daily Service Charge" sensor — the existing per-rate diagnostic sensor already exposes the daily supply rate directly, so a dedicated daily sensor would just duplicate it

## Implementation
- Extracted `_get_billing_period_start` out of the existing `_get_usage_period_dates` in `coordinator.py` (pure refactor) so both the usage fetch and the new billing-period math share the same `lastBillDate + 1` / 30-day-fallback logic
- Added `_find_service_charge_rate`, `get_billing_period_service_charge` to the coordinator
- Added `RedEnergyBillingPeriodServiceChargeSensor`, wired into the advanced-sensors block in `async_setup_entry`
- `last_reset` aligns with the 12 existing billing-period TOTAL sensors (`lastBillDate` via `_get_last_bill_reset()`), keeping the day-count math (`lastBillDate + 1`) separate from the statistics reset boundary
- Bumped manifest version to 1.17.0

Closes #71