### PR TITLE
fix: rename Total sensors to Current Period

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,13 @@ Since electricity-only concepts (solar, export, time-of-use tariffs, demand, car
 **Usage & Cost Tracking:**
 - Daily Import Usage - Daily imported energy (kWh/MJ)
 - Daily Export Usage *(electricity only)* - Daily exported energy (kWh)
-- Total Import Usage - Total imported energy since last bill
-- Total Export Usage *(electricity only)* - Total exported energy since last bill
+- Current Period Import Usage - Imported energy since last bill
+- Current Period Export Usage *(electricity only)* - Exported energy since last bill
 - Daily Import Cost - Daily import cost (AUD)
 - Daily Export Credit *(electricity only)* - Daily export credit (AUD)
-- Total Import Cost - Total import cost since last bill (AUD)
-- Total Export Credit *(electricity only)* - Total export credit since last bill (AUD)
-- Total Cost - Total cost since last bill (AUD)
+- Current Period Import Cost - Import cost since last bill (AUD)
+- Current Period Export Credit *(electricity only)* - Export credit since last bill (AUD)
+- Current Period Net Cost - Net cost (import minus export credit) since last bill (AUD)
 
 **Account & Service Information:**
 - NMI - National Meter Identifier

--- a/custom_components/red_energy/config_migration.py
+++ b/custom_components/red_energy/config_migration.py
@@ -34,7 +34,19 @@ CONFIG_VERSION_6 = 6  # Removed client_id from user config (now hardcoded)
 CONFIG_VERSION_7 = 7  # Removed service-type selection (always monitor both)
 CONFIG_VERSION_8 = 8  # Composite property IDs (fix accounts with shared accountNumber)
 CONFIG_VERSION_9 = 9  # Repair entries left with stale IDs by the v7->v8 migration
-CURRENT_CONFIG_VERSION = CONFIG_VERSION_9
+CONFIG_VERSION_10 = 10  # Renamed "Total" sensors to "Current Period" (issue #78)
+CURRENT_CONFIG_VERSION = CONFIG_VERSION_10
+
+# sensor_type suffixes renamed in v9->v10, old -> new. "Total" implied a
+# complete/lifetime figure, but these reset every billing cycle and only
+# ever represent a partial sum accruing since lastBillDate (issue #78).
+SENSOR_TYPE_RENAMES_V10: dict[str, str] = {
+    "total_cost": "current_period_net_cost",
+    "total_import_usage": "current_period_import_usage",
+    "total_export_usage": "current_period_export_usage",
+    "total_import_cost": "current_period_import_cost",
+    "total_export_credit": "current_period_export_credit",
+}
 
 
 class ConfigValidationError(Exception):
@@ -95,6 +107,10 @@ class RedEnergyConfigMigrator:
             # Migrate from version 8 to 9
             if current_version < CONFIG_VERSION_9:
                 migration_success &= await self._migrate_v8_to_v9(config_entry)
+
+            # Migrate from version 9 to 10
+            if current_version < CONFIG_VERSION_10:
+                migration_success &= await self._migrate_v9_to_v10(config_entry)
 
             if migration_success:
                 # Update version in config entry
@@ -375,6 +391,55 @@ class RedEnergyConfigMigrator:
         """
         _LOGGER.info("Migrating config entry from v8 to v9 - Repairing stale property IDs")
         return await self._remap_stale_property_ids(config_entry, "v8 to v9")
+
+    async def _migrate_v9_to_v10(self, config_entry: ConfigEntry) -> bool:
+        """Migrate from version 9 to 10 - Rename "Total" sensors to "Current Period".
+
+        "Total Cost", "Total Import Usage", "Total Export Usage", "Total
+        Import Cost", and "Total Export Credit" all report a partial sum
+        accruing since lastBillDate, reset every billing cycle - never a
+        complete/lifetime total (see issue #78). Their sensor_type suffix
+        is renamed here (SENSOR_TYPE_RENAMES_V10) so existing entities keep
+        their entity_id, history, and Energy Dashboard statistics rather
+        than going stale and being recreated under a new entity_id.
+
+        No API call is needed - unlike the v7->v8/v8->v9 property ID
+        repair, this is a purely local unique_id string rename.
+        """
+        _LOGGER.info("Migrating config entry from v9 to v10 - Renaming Total sensors to Current Period")
+
+        try:
+            from homeassistant.helpers import entity_registry as er
+
+            entity_registry = er.async_get(self.hass)
+            renamed_count = 0
+
+            for entity in er.async_entries_for_config_entry(entity_registry, config_entry.entry_id):
+                for old_suffix, new_suffix in SENSOR_TYPE_RENAMES_V10.items():
+                    old_segment = f"_{old_suffix}"
+                    if not entity.unique_id.endswith(old_segment):
+                        continue
+                    new_unique_id = entity.unique_id[: -len(old_segment)] + f"_{new_suffix}"
+                    entity_registry.async_update_entity(
+                        entity.entity_id, new_unique_id=new_unique_id
+                    )
+                    _LOGGER.info(
+                        "Migrated entity %s unique_id from %s to %s",
+                        entity.entity_id, entity.unique_id, new_unique_id
+                    )
+                    renamed_count += 1
+                    break
+
+            _LOGGER.info(
+                "Successfully completed v9 to v10 migration, renamed %d entit(ies)", renamed_count
+            )
+            return True
+
+        except Exception as err:
+            _LOGGER.error("Failed v9 to v10 migration: %s", err, exc_info=True)
+            # Don't fail the entire migration - the rename still applies for
+            # new entity creation, existing ones just won't be renamed.
+            return True
 
     async def _remap_stale_property_ids(self, config_entry: ConfigEntry, migration_label: str) -> bool:
         """Re-fetch properties and remap any selected_accounts entries that

--- a/custom_components/red_energy/const.py
+++ b/custom_components/red_energy/const.py
@@ -37,13 +37,17 @@ SENSOR_TYPE_PROJECTED_CHARGES: Final = "projected_charges"
 SENSOR_TYPE_DAILY_IMPORT_USAGE: Final = "daily_import_usage"
 SENSOR_TYPE_DAILY_EXPORT_USAGE: Final = "daily_export_usage"
 
-# Breakdown sensor types - Total (CORE)
-SENSOR_TYPE_TOTAL_IMPORT_USAGE: Final = "total_import_usage"
-SENSOR_TYPE_TOTAL_EXPORT_USAGE: Final = "total_export_usage"
+# Breakdown sensor types - Current billing period to date (CORE)
+# Named "current_period_*", not "total_*" - these reset every billing
+# cycle (see _get_last_bill_reset) and only ever represent a partial sum
+# accruing since lastBillDate, never a complete/lifetime total (issue #78).
+SENSOR_TYPE_CURRENT_PERIOD_IMPORT_USAGE: Final = "current_period_import_usage"
+SENSOR_TYPE_CURRENT_PERIOD_EXPORT_USAGE: Final = "current_period_export_usage"
 
-# Breakdown sensor types - Cost (CORE)
-SENSOR_TYPE_TOTAL_IMPORT_COST: Final = "total_import_cost"
-SENSOR_TYPE_TOTAL_EXPORT_CREDIT: Final = "total_export_credit"
+# Breakdown sensor types - Current billing period to date, cost (CORE)
+SENSOR_TYPE_CURRENT_PERIOD_IMPORT_COST: Final = "current_period_import_cost"
+SENSOR_TYPE_CURRENT_PERIOD_EXPORT_CREDIT: Final = "current_period_export_credit"
+SENSOR_TYPE_CURRENT_PERIOD_NET_COST: Final = "current_period_net_cost"
 
 # Breakdown sensor types - Time period import (ADVANCED)
 SENSOR_TYPE_PEAK_IMPORT_USAGE: Final = "peak_import_usage"

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.18.0"
+  "version": "1.18.1"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -34,6 +34,11 @@ from .const import (
     SENSOR_TYPE_CORRECTED_OFFPEAK_IMPORT,
     SENSOR_TYPE_CORRECTED_PEAK_IMPORT,
     SENSOR_TYPE_CORRECTED_SHOULDER_IMPORT,
+    SENSOR_TYPE_CURRENT_PERIOD_EXPORT_CREDIT,
+    SENSOR_TYPE_CURRENT_PERIOD_EXPORT_USAGE,
+    SENSOR_TYPE_CURRENT_PERIOD_IMPORT_COST,
+    SENSOR_TYPE_CURRENT_PERIOD_IMPORT_USAGE,
+    SENSOR_TYPE_CURRENT_PERIOD_NET_COST,
     SENSOR_TYPE_DAILY_AVERAGE,
     SENSOR_TYPE_DISTRIBUTOR,
     SENSOR_TYPE_EFFICIENCY,
@@ -347,7 +352,7 @@ class RedEnergyBaseSensor(CoordinatorEntity, SensorEntity):
 
 
 class RedEnergyCostSensor(RedEnergyBaseSensor):
-    """Red Energy total cost sensor."""
+    """Red Energy current billing period net cost sensor (to date, resets each cycle)."""
 
     def __init__(
         self,
@@ -357,7 +362,7 @@ class RedEnergyCostSensor(RedEnergyBaseSensor):
         service_type: str,
     ) -> None:
         """Initialize the cost sensor."""
-        super().__init__(coordinator, config_entry, property_id, service_type, "total_cost")
+        super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_CURRENT_PERIOD_NET_COST)
         
         self._attr_device_class = SensorDeviceClass.MONETARY
         self._attr_native_unit_of_measurement = "AUD"
@@ -1411,7 +1416,7 @@ class RedEnergyDailyExportUsageSensor(RedEnergyBaseSensor):
 
 
 class RedEnergyTotalImportUsageSensor(RedEnergyBaseSensor):
-    """Red Energy total import usage sensor (30-day period)."""
+    """Red Energy current billing period import usage sensor (to date, resets each cycle)."""
 
     def __init__(
         self,
@@ -1420,8 +1425,10 @@ class RedEnergyTotalImportUsageSensor(RedEnergyBaseSensor):
         property_id: str,
         service_type: str,
     ) -> None:
-        """Initialize the total import usage sensor."""
-        super().__init__(coordinator, config_entry, property_id, service_type, "total_import_usage")
+        """Initialize the current period import usage sensor."""
+        super().__init__(
+            coordinator, config_entry, property_id, service_type, SENSOR_TYPE_CURRENT_PERIOD_IMPORT_USAGE
+        )
 
         if service_type == SERVICE_TYPE_ELECTRICITY:
             self._attr_device_class = SensorDeviceClass.ENERGY
@@ -1465,7 +1472,7 @@ class RedEnergyTotalImportUsageSensor(RedEnergyBaseSensor):
 
 
 class RedEnergyTotalExportUsageSensor(RedEnergyBaseSensor):
-    """Red Energy total export usage sensor (30-day period)."""
+    """Red Energy current billing period export usage sensor (to date, resets each cycle)."""
 
     _electricity_only = True
 
@@ -1476,8 +1483,10 @@ class RedEnergyTotalExportUsageSensor(RedEnergyBaseSensor):
         property_id: str,
         service_type: str,
     ) -> None:
-        """Initialize the total export usage sensor."""
-        super().__init__(coordinator, config_entry, property_id, service_type, "total_export_usage")
+        """Initialize the current period export usage sensor."""
+        super().__init__(
+            coordinator, config_entry, property_id, service_type, SENSOR_TYPE_CURRENT_PERIOD_EXPORT_USAGE
+        )
 
         if service_type == SERVICE_TYPE_ELECTRICITY:
             self._attr_device_class = SensorDeviceClass.ENERGY
@@ -1522,7 +1531,7 @@ class RedEnergyTotalExportUsageSensor(RedEnergyBaseSensor):
 
 
 class RedEnergyTotalImportCostSensor(RedEnergyBaseSensor):
-    """Red Energy total import cost sensor."""
+    """Red Energy current billing period import cost sensor (to date, resets each cycle)."""
 
     def __init__(
         self,
@@ -1531,8 +1540,10 @@ class RedEnergyTotalImportCostSensor(RedEnergyBaseSensor):
         property_id: str,
         service_type: str,
     ) -> None:
-        """Initialize the total import cost sensor."""
-        super().__init__(coordinator, config_entry, property_id, service_type, "total_import_cost")
+        """Initialize the current period import cost sensor."""
+        super().__init__(
+            coordinator, config_entry, property_id, service_type, SENSOR_TYPE_CURRENT_PERIOD_IMPORT_COST
+        )
 
         self._attr_device_class = SensorDeviceClass.MONETARY
         self._attr_native_unit_of_measurement = "AUD"
@@ -1566,7 +1577,7 @@ class RedEnergyTotalImportCostSensor(RedEnergyBaseSensor):
 
 
 class RedEnergyTotalExportCreditSensor(RedEnergyBaseSensor):
-    """Red Energy total export credit sensor."""
+    """Red Energy current billing period export credit sensor (to date, resets each cycle)."""
 
     _electricity_only = True
 
@@ -1577,8 +1588,10 @@ class RedEnergyTotalExportCreditSensor(RedEnergyBaseSensor):
         property_id: str,
         service_type: str,
     ) -> None:
-        """Initialize the total export credit sensor."""
-        super().__init__(coordinator, config_entry, property_id, service_type, "total_export_credit")
+        """Initialize the current period export credit sensor."""
+        super().__init__(
+            coordinator, config_entry, property_id, service_type, SENSOR_TYPE_CURRENT_PERIOD_EXPORT_CREDIT
+        )
 
         self._attr_device_class = SensorDeviceClass.MONETARY
         self._attr_native_unit_of_measurement = "AUD"

--- a/tests/test_config_migration_v10.py
+++ b/tests/test_config_migration_v10.py
@@ -1,0 +1,174 @@
+"""Test config migration to v10 - rename "Total" sensors to "Current Period".
+
+"Total Cost", "Total Import Usage", "Total Export Usage", "Total Import
+Cost", and "Total Export Credit" all report a partial sum accruing since
+the current billing cycle's lastBillDate, not a complete/lifetime total
+(see issue #78). This migration renames their sensor_type suffix so
+existing entities keep their history/statistics rather than going stale
+and being recreated under a new entity_id.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.red_energy.config_migration import (
+    CONFIG_VERSION_10,
+    CURRENT_CONFIG_VERSION,
+    RedEnergyConfigMigrator,
+    SENSOR_TYPE_RENAMES_V10,
+)
+from custom_components.red_energy.const import DOMAIN
+
+
+def _make_config_entry(version=9):
+    entry = MagicMock()
+    entry.version = version
+    entry.entry_id = "entry1"
+    entry.data = {
+        "username": "test@example.com",
+        "password": "testpass",
+        "selected_accounts": ["1000001"],
+        "services": ["electricity", "gas"],
+    }
+    return entry
+
+
+def _registry_entry(entity_id, unique_id):
+    entry = MagicMock()
+    entry.entity_id = entity_id
+    entry.unique_id = unique_id
+    entry.platform = DOMAIN
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_renames_all_five_total_sensor_unique_ids():
+    entry = _make_config_entry(version=9)
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    old_unique_ids = [
+        "red_energy_entry1_1000001_electricity_total_cost",
+        "red_energy_entry1_1000001_electricity_total_import_usage",
+        "red_energy_entry1_1000001_electricity_total_export_usage",
+        "red_energy_entry1_1000001_electricity_total_import_cost",
+        "red_energy_entry1_1000001_electricity_total_export_credit",
+    ]
+    registry_entries = [
+        _registry_entry(f"sensor.entity_{i}", uid) for i, uid in enumerate(old_unique_ids)
+    ]
+
+    mock_entity_registry = MagicMock()
+    mock_entity_registry.async_update_entity = MagicMock()
+
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get", return_value=mock_entity_registry
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_config_entry",
+        return_value=registry_entries,
+    ):
+        migrator = RedEnergyConfigMigrator(hass)
+        result = await migrator.async_migrate_config_entry(entry)
+
+    assert result is True
+
+    expected_new_ids = {
+        "red_energy_entry1_1000001_electricity_current_period_net_cost",
+        "red_energy_entry1_1000001_electricity_current_period_import_usage",
+        "red_energy_entry1_1000001_electricity_current_period_export_usage",
+        "red_energy_entry1_1000001_electricity_current_period_import_cost",
+        "red_energy_entry1_1000001_electricity_current_period_export_credit",
+    }
+    actual_new_ids = {
+        call.kwargs["new_unique_id"]
+        for call in mock_entity_registry.async_update_entity.call_args_list
+    }
+    assert actual_new_ids == expected_new_ids
+
+    hass.config_entries.async_update_entry.assert_any_call(entry, version=CURRENT_CONFIG_VERSION)
+
+
+@pytest.mark.asyncio
+async def test_entities_with_non_matching_sensor_type_are_untouched():
+    """Entities in this config entry whose unique_id doesn't end in one of
+    the renamed sensor_type suffixes (e.g. daily_import_usage) must be left alone."""
+    entry = _make_config_entry(version=9)
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    unrelated_entry = _registry_entry(
+        "sensor.daily_import", "red_energy_entry1_1000001_electricity_daily_import_usage"
+    )
+
+    mock_entity_registry = MagicMock()
+    mock_entity_registry.async_update_entity = MagicMock()
+
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get", return_value=mock_entity_registry
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_config_entry",
+        return_value=[unrelated_entry],
+    ):
+        migrator = RedEnergyConfigMigrator(hass)
+        result = await migrator.async_migrate_config_entry(entry)
+
+    assert result is True
+    mock_entity_registry.async_update_entity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_already_renamed_entity_is_a_noop():
+    """An entity already using the new sensor_type (e.g. set up fresh after
+    this migration shipped) must not be touched again."""
+    entry = _make_config_entry(version=9)
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    already_renamed = _registry_entry(
+        "sensor.entity_0", "red_energy_entry1_1000001_electricity_current_period_net_cost"
+    )
+
+    mock_entity_registry = MagicMock()
+    mock_entity_registry.async_update_entity = MagicMock()
+
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get", return_value=mock_entity_registry
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_config_entry",
+        return_value=[already_renamed],
+    ):
+        migrator = RedEnergyConfigMigrator(hass)
+        result = await migrator._migrate_v9_to_v10(entry)
+
+    assert result is True
+    mock_entity_registry.async_update_entity.assert_not_called()
+
+
+def test_config_version_10_is_current():
+    assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_10
+    assert CONFIG_VERSION_10 == 10
+
+
+def test_sensor_type_renames_v10_covers_all_total_sensors():
+    """Every "total_*" sensor_type in the codebase must have a rename entry -
+    otherwise a sensor slips through this migration and keeps its
+    misleading name/entity_id forever for existing installs."""
+    assert SENSOR_TYPE_RENAMES_V10 == {
+        "total_cost": "current_period_net_cost",
+        "total_import_usage": "current_period_import_usage",
+        "total_export_usage": "current_period_export_usage",
+        "total_import_cost": "current_period_import_cost",
+        "total_export_credit": "current_period_export_credit",
+    }
+
+
+def test_config_flow_version_matches_current_config_version():
+    """Home Assistant core only calls async_migrate_entry when
+    ConfigEntry.version != ConfigFlow.VERSION - if these two drift apart,
+    every migration in this file becomes dead code for existing entries,
+    regardless of how correct the migration logic itself is."""
+    from custom_components.red_energy.config_flow import ConfigFlow
+
+    assert ConfigFlow.VERSION == CURRENT_CONFIG_VERSION

--- a/tests/test_config_migration_v9.py
+++ b/tests/test_config_migration_v9.py
@@ -133,16 +133,10 @@ async def test_v8_entry_with_matching_ids_is_a_noop():
     assert not data_updates
 
 
-def test_config_version_9_is_current():
-    assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_9
+def test_config_version_9_value():
+    """CONFIG_VERSION_9 == 9 is a fixed historical fact, independent of
+    whichever version is CURRENT_CONFIG_VERSION today. The "is this the
+    current version" and "does ConfigFlow.VERSION match" checks belong to
+    whichever migration test file introduced the latest version - see
+    test_config_migration_v10.py."""
     assert CONFIG_VERSION_9 == 9
-
-
-def test_config_flow_version_matches_current_config_version():
-    """Home Assistant core only calls async_migrate_entry when
-    ConfigEntry.version != ConfigFlow.VERSION - if these two drift apart,
-    every migration in this file becomes dead code for existing entries,
-    regardless of how correct the migration logic itself is."""
-    from custom_components.red_energy.config_flow import ConfigFlow
-
-    assert ConfigFlow.VERSION == CURRENT_CONFIG_VERSION

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -164,15 +164,17 @@ class TestSensorDisplayNames:
         assert "prop-001" not in sensor._attr_name
         assert "Test Property" not in sensor._attr_name
 
-    def test_total_cost_sensor_display_name(self):
-        """Test total_cost sensor display name."""
+    def test_current_period_net_cost_sensor_display_name(self):
+        """Test current_period_net_cost sensor display name.
+
+        Not "Total Cost" - this is a partial sum accruing since the current
+        billing cycle's lastBillDate, not a complete/lifetime total (#78)."""
         coordinator = create_mock_coordinator()
         config_entry = create_mock_config_entry()
-        
+
         sensor = RedEnergyCostSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        
-        assert "Total Cost" in sensor._attr_name
-        assert "Total_Cost" not in sensor._attr_name
+
+        assert sensor._attr_name == "Current Period Net Cost"
 
     def test_daily_average_sensor_display_name(self):
         """Test daily_average sensor display name."""
@@ -370,46 +372,50 @@ class TestImportExportSensors:
         assert sensor.icon == "mdi:solar-power"
 
     def test_total_import_usage_sensor(self):
-        """Test total import usage sensor."""
+        """Test current period import usage sensor."""
         coordinator = create_mock_coordinator()
         config_entry = create_mock_config_entry()
-        
+
         sensor = RedEnergyTotalImportUsageSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        
+
         assert sensor.native_value == 83.0
         assert sensor.state_class == SensorStateClass.TOTAL
+        assert sensor._attr_name == "Current Period Import Usage"
 
     def test_total_export_usage_sensor(self):
-        """Test total export usage sensor."""
+        """Test current period export usage sensor."""
         coordinator = create_mock_coordinator()
         config_entry = create_mock_config_entry()
-        
+
         sensor = RedEnergyTotalExportUsageSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        
+
         assert sensor.native_value == 15.0
+        assert sensor._attr_name == "Current Period Export Usage"
 
 
 class TestCostCreditSensors:
     """Test cost and credit sensors."""
 
     def test_total_import_cost_sensor(self):
-        """Test total import cost sensor."""
+        """Test current period import cost sensor."""
         coordinator = create_mock_coordinator()
         config_entry = create_mock_config_entry()
-        
+
         sensor = RedEnergyTotalImportCostSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        
+
         assert sensor.native_value == 23.24
         assert sensor.native_unit_of_measurement == "AUD"
+        assert sensor._attr_name == "Current Period Import Cost"
 
     def test_total_export_credit_sensor(self):
-        """Test total export credit sensor."""
+        """Test current period export credit sensor."""
         coordinator = create_mock_coordinator()
         config_entry = create_mock_config_entry()
-        
+
         sensor = RedEnergyTotalExportCreditSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        
+
         assert sensor.native_value == 2.10
+        assert sensor._attr_name == "Current Period Export Credit"
 
 
 class TestTimePeriodSensors:


### PR DESCRIPTION
## Summary
- Renames 5 sensors: Total Cost, Total Import Usage, Total Export Usage, Total Import Cost, Total Export Credit -> Current Period Net Cost, Current Period Import Usage, Current Period Export Usage, Current Period Import Cost, Current Period Export Credit
- "Total" implied a complete/lifetime figure, but these reset every billing cycle and only ever represent a partial sum accruing since `lastBillDate`
- "Total Cost" additionally renamed to "Current Period Net Cost" to disclose it's net of export credit, unlike its correctly-scoped Import Cost/Export Credit siblings
- Wires the previously-unused `SENSOR_TYPE_TOTAL_*` const definitions into their sensor classes instead of bare string literals (were dead code)

## Migration
- New config version 10 (`_migrate_v9_to_v10`) renames existing entities' `unique_id` suffix in place via the entity registry, so entity_id, history, and Energy Dashboard statistics carry over rather than the old entities going stale
- No API call needed - purely a local string rename, unlike the v7->v8/v8->v9 migrations

## Related
Closes #78.