### PR TITLE
fix: GST-inclusive costs, projection off-by-one, new Projected Charges

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ Since electricity-only concepts (solar, export, time-of-use tariffs, demand, car
 - Daily Export Usage *(electricity only)* - Daily exported energy (kWh)
 - Current Period Import Usage - Imported energy since last bill
 - Current Period Export Usage *(electricity only)* - Exported energy since last bill
-- Daily Import Cost - Daily import cost (AUD)
+- Daily Import Cost - Daily import cost, GST-inclusive (AUD)
 - Daily Export Credit *(electricity only)* - Daily export credit (AUD)
-- Current Period Import Cost - Import cost since last bill (AUD)
+- Current Period Import Cost - Import cost since last bill, GST-inclusive (AUD)
 - Current Period Export Credit *(electricity only)* - Export credit since last bill (AUD)
-- Current Period Net Cost - Net cost (import minus export credit) since last bill (AUD)
+- Current Period Net Cost - Net cost (GST-inclusive import minus export credit) since last bill (AUD)
 
 **Account & Service Information:**
 - NMI - National Meter Identifier
@@ -128,6 +128,8 @@ Enabled via the "Advanced Sensors" integration option. **13 sensors for electric
 - Monthly Average - Projected monthly usage (billing period-adjusted)
 - Peak Usage - Highest single-day usage with date
 - Efficiency *(electricity only)* - Usage consistency efficiency rating (0-100%)
+- Projected Net Cost - Estimated net energy cost (import minus export credit) for the full billing cycle, extrapolated from usage to date. GST-inclusive; not Red Energy's own figure
+- Projected Charges - Projected Net Cost plus the daily service/supply charge projected across the full cycle, for a fuller bill estimate. GST-inclusive; not Red Energy's own figure
 
 **Time-of-Use Breakdown** *(electricity only - gas has no ToU tariff)*:
 - Peak/Offpeak/Shoulder Import Usage

--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ Since electricity-only concepts (solar, export, time-of-use tariffs, demand, car
 - Daily Export Usage *(electricity only)* - Daily exported energy (kWh)
 - Current Period Import Usage - Imported energy since last bill
 - Current Period Export Usage *(electricity only)* - Exported energy since last bill
-- Daily Import Cost - Daily import cost, GST-inclusive (AUD)
+- Daily Import Cost - Daily import cost, GST-exclusive (AUD)
 - Daily Export Credit *(electricity only)* - Daily export credit (AUD)
-- Current Period Import Cost - Import cost since last bill, GST-inclusive (AUD)
+- Current Period Import Cost - Import cost since last bill, GST-exclusive (AUD)
 - Current Period Export Credit *(electricity only)* - Export credit since last bill (AUD)
-- Current Period Net Cost - Net cost (GST-inclusive import minus export credit) since last bill (AUD)
+- Current Period Net Cost - Net cost (GST-exclusive import minus export credit) since last bill (AUD)
 
 **Account & Service Information:**
 - NMI - National Meter Identifier

--- a/custom_components/red_energy/config_migration.py
+++ b/custom_components/red_energy/config_migration.py
@@ -35,7 +35,8 @@ CONFIG_VERSION_7 = 7  # Removed service-type selection (always monitor both)
 CONFIG_VERSION_8 = 8  # Composite property IDs (fix accounts with shared accountNumber)
 CONFIG_VERSION_9 = 9  # Repair entries left with stale IDs by the v7->v8 migration
 CONFIG_VERSION_10 = 10  # Renamed "Total" sensors to "Current Period" (issue #78)
-CURRENT_CONFIG_VERSION = CONFIG_VERSION_10
+CONFIG_VERSION_11 = 11  # Renamed Projected Charges to Projected Net Cost (issue #77)
+CURRENT_CONFIG_VERSION = CONFIG_VERSION_11
 
 # sensor_type suffixes renamed in v9->v10, old -> new. "Total" implied a
 # complete/lifetime figure, but these reset every billing cycle and only
@@ -46,6 +47,15 @@ SENSOR_TYPE_RENAMES_V10: dict[str, str] = {
     "total_export_usage": "current_period_export_usage",
     "total_import_cost": "current_period_import_cost",
     "total_export_credit": "current_period_export_credit",
+}
+
+# sensor_type suffixes renamed in v10->v11, old -> new. The original
+# "Projected Charges" sensor (issue #75) is renamed to "Projected Net
+# Cost" to disclose it's energy-only (no service charge) and to make room
+# for a new "Projected Charges" sensor that includes the service charge
+# (issue #77).
+SENSOR_TYPE_RENAMES_V11: dict[str, str] = {
+    "projected_charges": "projected_net_cost",
 }
 
 
@@ -111,6 +121,10 @@ class RedEnergyConfigMigrator:
             # Migrate from version 9 to 10
             if current_version < CONFIG_VERSION_10:
                 migration_success &= await self._migrate_v9_to_v10(config_entry)
+
+            # Migrate from version 10 to 11
+            if current_version < CONFIG_VERSION_11:
+                migration_success &= await self._migrate_v10_to_v11(config_entry)
 
             if migration_success:
                 # Update version in config entry
@@ -402,11 +416,38 @@ class RedEnergyConfigMigrator:
         is renamed here (SENSOR_TYPE_RENAMES_V10) so existing entities keep
         their entity_id, history, and Energy Dashboard statistics rather
         than going stale and being recreated under a new entity_id.
+        """
+        return await self._remap_sensor_type_suffixes(
+            config_entry, SENSOR_TYPE_RENAMES_V10, "v9 to v10"
+        )
+
+    async def _migrate_v10_to_v11(self, config_entry: ConfigEntry) -> bool:
+        """Migrate from version 10 to 11 - Rename Projected Charges to Projected Net Cost.
+
+        The original "Projected Charges" sensor (issue #75) didn't disclose
+        it's energy-only (excludes the daily service/supply charge) - see
+        issue #77. Renamed to "Projected Net Cost" (SENSOR_TYPE_RENAMES_V11)
+        so existing entities keep their entity_id, history, and Energy
+        Dashboard statistics, and to free up "Projected Charges" for the new
+        sensor that does include the service charge.
+        """
+        return await self._remap_sensor_type_suffixes(
+            config_entry, SENSOR_TYPE_RENAMES_V11, "v10 to v11"
+        )
+
+    async def _remap_sensor_type_suffixes(
+        self, config_entry: ConfigEntry, renames: dict[str, str], migration_label: str
+    ) -> bool:
+        """Rename any entity whose unique_id ends in one of `renames`' old
+        sensor_type suffixes to the corresponding new suffix, in place -
+        preserving entity_id, history, and Energy Dashboard statistics
+        rather than the old entity going stale and being recreated fresh.
 
         No API call is needed - unlike the v7->v8/v8->v9 property ID
-        repair, this is a purely local unique_id string rename.
+        repair, this is a purely local unique_id string rename. Shared by
+        the v9->v10 and v10->v11 steps.
         """
-        _LOGGER.info("Migrating config entry from v9 to v10 - Renaming Total sensors to Current Period")
+        _LOGGER.info("Migrating config entry %s - Renaming sensor types", migration_label)
 
         try:
             from homeassistant.helpers import entity_registry as er
@@ -415,7 +456,7 @@ class RedEnergyConfigMigrator:
             renamed_count = 0
 
             for entity in er.async_entries_for_config_entry(entity_registry, config_entry.entry_id):
-                for old_suffix, new_suffix in SENSOR_TYPE_RENAMES_V10.items():
+                for old_suffix, new_suffix in renames.items():
                     old_segment = f"_{old_suffix}"
                     if not entity.unique_id.endswith(old_segment):
                         continue
@@ -431,12 +472,12 @@ class RedEnergyConfigMigrator:
                     break
 
             _LOGGER.info(
-                "Successfully completed v9 to v10 migration, renamed %d entit(ies)", renamed_count
+                "Successfully completed %s migration, renamed %d entit(ies)", migration_label, renamed_count
             )
             return True
 
         except Exception as err:
-            _LOGGER.error("Failed v9 to v10 migration: %s", err, exc_info=True)
+            _LOGGER.error("Failed %s migration: %s", migration_label, err, exc_info=True)
             # Don't fail the entire migration - the rename still applies for
             # new entity creation, existing ones just won't be renamed.
             return True

--- a/custom_components/red_energy/const.py
+++ b/custom_components/red_energy/const.py
@@ -31,6 +31,10 @@ SENSOR_TYPE_DAILY_AVERAGE: Final = "daily_average"
 SENSOR_TYPE_MONTHLY_AVERAGE: Final = "monthly_average"
 SENSOR_TYPE_PEAK_USAGE: Final = "peak_usage"
 SENSOR_TYPE_EFFICIENCY: Final = "efficiency"
+# Forward-looking estimates, not Red Energy's own figures (issues #75, #77).
+# "Projected" (not "Current Period") distinguishes these forecast sensors
+# from the actual/to-date SENSOR_TYPE_CURRENT_PERIOD_NET_COST sensor above.
+SENSOR_TYPE_PROJECTED_NET_COST: Final = "projected_net_cost"
 SENSOR_TYPE_PROJECTED_CHARGES: Final = "projected_charges"
 
 # Breakdown sensor types - Daily (CORE)
@@ -112,6 +116,13 @@ SERVICE_TYPE_ELECTRICITY: Final = "electricity"
 SERVICE_TYPE_GAS: Final = "gas"
 
 API_TIMEOUT: Final = 30
+
+# Red Energy's consumptionDollar/import_cost field is ex-GST (see api.py's
+# _normalize_usage_entry docstring); every cost/estimate/projection sensor
+# in this integration must be GST-inclusive, so this uplifts the import
+# component wherever it's read. generationDollar/export_credit (FIT/solar
+# export credit) has no GST component and is never uplifted.
+GST_MULTIPLIER: Final = 1.10
 
 # Configuration flow
 STEP_USER: Final = "user"

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -24,6 +24,7 @@ from .performance import PerformanceMonitor, DataProcessor
 from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    GST_MULTIPLIER,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -576,12 +577,13 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         return usage_data[-1].get("usage", 0.0)
 
     def get_total_cost(self, property_id: str, service_type: str) -> float | None:
-        """Get the total cost for a property and service."""
-        service_data = self.get_service_usage(property_id, service_type)
-        if not service_data or "usage_data" not in service_data:
-            return None
-        
-        return service_data["usage_data"].get("total_cost", 0.0)
+        """Get the total (GST-inclusive, net of export credit) cost for a property and service.
+
+        Delegates to get_net_total_cost rather than reading the pre-aggregated
+        usage_data["total_cost"] field, which is ex-GST on the import side
+        (see get_net_total_cost/get_total_import_cost for the GST uplift).
+        """
+        return self.get_net_total_cost(property_id, service_type)
 
     def get_total_usage(self, property_id: str, service_type: str) -> float | None:
         """Get the total usage for a property and service."""
@@ -711,16 +713,12 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         except (ValueError, TypeError):
             return None
 
-        last_bill_date_str = service_metadata.get("lastBillDate")
-        if last_bill_date_str:
-            try:
-                cycle_start = datetime.strptime(last_bill_date_str, "%Y-%m-%d").date()
-            except (ValueError, TypeError):
-                cycle_start = billing_period_start - timedelta(days=1)
-        else:
-            cycle_start = billing_period_start - timedelta(days=1)
-
-        days_in_cycle = (next_bill_date - cycle_start).days
+        # nextBillDate is an exclusive boundary - the first day of the *next*
+        # cycle, not a chargeable day of this one - symmetric with lastBillDate
+        # being excluded via the +1 day in billing_period_start above. Using
+        # billing_period_start (not lastBillDate) as the cycle_days anchor
+        # keeps both boundaries treated the same way (issue #70 follow-up).
+        days_in_cycle = (next_bill_date - billing_period_start).days
         if days_in_cycle <= 0:
             return None
 
@@ -729,6 +727,41 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
             "net_cost_to_date": net_cost_to_date,
             "days_elapsed": days_elapsed,
             "days_in_cycle": days_in_cycle,
+        }
+
+    def get_estimated_current_period_charges(self, property_id: str, service_type: str) -> dict[str, Any] | None:
+        """Estimate the full billing cycle's total charge, energy + service charge (issue #77).
+
+        get_projected_charges alone is energy-only (net usage cost), not a
+        full bill estimate - it excludes the daily service/supply charge.
+        This adds that charge, projected across the same days_in_cycle:
+
+            estimated_charges = projected_net_cost + (service_charge_rate * days_in_cycle)
+
+        Both terms are GST-inclusive (get_total_cost is uplifted at the
+        source; rate_incl_gst_dollars already is), so no further GST
+        adjustment is needed here.
+
+        Returns None when there's no daily service-charge rate (some plans
+        don't have one) or when the underlying net-cost projection itself
+        is unavailable.
+        """
+        rate = self._find_service_charge_rate(property_id, service_type)
+        if rate is None:
+            return None
+
+        projection = self.get_projected_charges(property_id, service_type)
+        if projection is None:
+            return None
+
+        estimated_service_charge = rate["rate_incl_gst_dollars"] * projection["days_in_cycle"]
+
+        return {
+            "estimated_charges": projection["projected_charges"] + estimated_service_charge,
+            "estimated_net_cost": projection["projected_charges"],
+            "estimated_service_charge": estimated_service_charge,
+            "days_in_cycle": projection["days_in_cycle"],
+            "service_rate_incl_gst": rate["rate_incl_gst_dollars"],
         }
 
     def get_cl2_inference(self, property_id: str, service_type: str) -> dict[str, Any] | None:
@@ -893,31 +926,43 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         return sum(entry.get(field_name, 0) for entry in usage_data)
 
     def get_total_import_cost(self, property_id: str, service_type: str) -> float | None:
-        """Get total import cost over period."""
+        """Get total import cost over period, GST-inclusive.
+
+        entry["import_cost"] is sourced from consumptionDollar, which Red
+        Energy's API returns ex-GST (see api.py's _normalize_usage_entry
+        docstring) - uplifted here by GST_MULTIPLIER so every cost/estimate/
+        projection sensor in the integration is consistently GST-inclusive.
+        """
         service_data = self.get_service_usage(property_id, service_type)
         if not service_data or "usage_data" not in service_data:
             return None
-        
+
         usage_data = service_data["usage_data"].get("usage_data", [])
-        return sum(entry.get("import_cost", 0) for entry in usage_data)
+        ex_gst_total = sum(entry.get("import_cost", 0) for entry in usage_data)
+        return ex_gst_total * GST_MULTIPLIER
 
     def get_total_export_credit(self, property_id: str, service_type: str) -> float | None:
-        """Get total export credit over period."""
+        """Get total export credit over period.
+
+        Not GST-uplifted: generationDollar (FIT/solar export credit) is not
+        a GST-bearing supply, so entry["export_credit"] has no GST component
+        to add or strip.
+        """
         service_data = self.get_service_usage(property_id, service_type)
         if not service_data or "usage_data" not in service_data:
             return None
-        
+
         usage_data = service_data["usage_data"].get("usage_data", [])
         return sum(entry.get("export_credit", 0) for entry in usage_data)
 
     def get_net_total_cost(self, property_id: str, service_type: str) -> float | None:
-        """Get net total cost (import - export) over period."""
+        """Get net total cost (GST-inclusive import - export credit) over period."""
         import_cost = self.get_total_import_cost(property_id, service_type)
         export_credit = self.get_total_export_credit(property_id, service_type)
-        
+
         if import_cost is None or export_credit is None:
             return None
-        
+
         return import_cost - export_credit
 
     def get_max_demand_data(self, property_id: str, service_type: str) -> dict[str, Any] | None:
@@ -962,9 +1007,9 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         return sum(entry.get("carbon_emission_tonne", 0) for entry in usage_data)
 
     def get_latest_import_cost(self, property_id: str, service_type: str) -> float | None:
-        """Get the most recent daily import cost."""
+        """Get the most recent daily import cost, GST-inclusive (see get_total_import_cost)."""
         entry = self._get_latest_usage_entry(property_id, service_type)
-        return entry.get("import_cost", 0.0) if entry else None
+        return entry.get("import_cost", 0.0) * GST_MULTIPLIER if entry else None
 
     def get_latest_export_credit(self, property_id: str, service_type: str) -> float | None:
         """Get the most recent daily export credit."""

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -577,11 +577,13 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         return usage_data[-1].get("usage", 0.0)
 
     def get_total_cost(self, property_id: str, service_type: str) -> float | None:
-        """Get the total (GST-inclusive, net of export credit) cost for a property and service.
+        """Get the total (GST-exclusive, net of export credit) cost for a property and service.
 
-        Delegates to get_net_total_cost rather than reading the pre-aggregated
-        usage_data["total_cost"] field, which is ex-GST on the import side
-        (see get_net_total_cost/get_total_import_cost for the GST uplift).
+        Delegates to get_net_total_cost, which sums import_cost/export_credit
+        directly, rather than reading the pre-aggregated usage_data["total_cost"]
+        field - both are ex-GST on the import side, but computing it here
+        keeps this and get_net_total_cost as a single source of truth rather
+        than two aggregations that could drift apart.
         """
         return self.get_net_total_cost(property_id, service_type)
 
@@ -664,13 +666,20 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         return rate["rate_incl_gst_dollars"] * represented_day_count
 
     def get_projected_charges(self, property_id: str, service_type: str) -> dict[str, Any] | None:
-        """Estimate the current billing cycle's total charge.
+        """Estimate the current billing cycle's total charge, GST-inclusive.
 
         Red Energy's API has no "projected charges" field (see issue #75) -
-        this linearly extrapolates net cost-to-date (get_total_cost, which
-        is import cost minus export credit) across the full billing cycle:
+        this linearly extrapolates GST-inclusive net cost-to-date across the
+        full billing cycle:
 
             net_cost_to_date / days_elapsed * days_in_cycle
+
+        net_cost_to_date is (import_cost * GST_MULTIPLIER) - export_credit,
+        computed here rather than via get_total_cost/get_net_total_cost -
+        those are GST-exclusive (feed Current Period Import Cost/Net Cost,
+        which disclose their ex-GST basis via a "gst_basis" attribute) -
+        uplifting their already-net result would incorrectly inflate the
+        export_credit component too, since it has no GST component itself.
 
         days_elapsed uses the latest completed usageDate as the period end
         (not datetime.now()) so a day with no confirmed usage yet is never
@@ -683,9 +692,11 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         "days_elapsed", and "days_in_cycle" so sensor attributes can be
         sourced from the same calculation rather than re-deriving it.
         """
-        net_cost_to_date = self.get_total_cost(property_id, service_type)
-        if net_cost_to_date is None:
+        import_cost_ex_gst = self.get_total_import_cost(property_id, service_type)
+        export_credit = self.get_total_export_credit(property_id, service_type)
+        if import_cost_ex_gst is None or export_credit is None:
             return None
+        net_cost_to_date = (import_cost_ex_gst * GST_MULTIPLIER) - export_credit
 
         latest_usage_date_str = self.get_latest_usage_date(property_id, service_type)
         if not latest_usage_date_str:
@@ -738,9 +749,9 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
 
             estimated_charges = projected_net_cost + (service_charge_rate * days_in_cycle)
 
-        Both terms are GST-inclusive (get_total_cost is uplifted at the
-        source; rate_incl_gst_dollars already is), so no further GST
-        adjustment is needed here.
+        Both terms are GST-inclusive (get_projected_charges computes its
+        own GST-inclusive net_cost_to_date; rate_incl_gst_dollars already
+        is), so no further GST adjustment is needed here.
 
         Returns None when there's no daily service-charge rate (some plans
         don't have one) or when the underlying net-cost projection itself
@@ -926,20 +937,22 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         return sum(entry.get(field_name, 0) for entry in usage_data)
 
     def get_total_import_cost(self, property_id: str, service_type: str) -> float | None:
-        """Get total import cost over period, GST-inclusive.
+        """Get total import cost over period, GST-exclusive.
 
         entry["import_cost"] is sourced from consumptionDollar, which Red
         Energy's API returns ex-GST (see api.py's _normalize_usage_entry
-        docstring) - uplifted here by GST_MULTIPLIER so every cost/estimate/
-        projection sensor in the integration is consistently GST-inclusive.
+        docstring) and is returned here as-is. Feeds Current Period Import
+        Cost / Current Period Net Cost, which are ex-GST and disclose this
+        via a "gst_basis" attribute. get_projected_charges applies its own
+        GST uplift for the forward-looking Projected Net Cost/Charges
+        sensors, which are GST-inclusive.
         """
         service_data = self.get_service_usage(property_id, service_type)
         if not service_data or "usage_data" not in service_data:
             return None
 
         usage_data = service_data["usage_data"].get("usage_data", [])
-        ex_gst_total = sum(entry.get("import_cost", 0) for entry in usage_data)
-        return ex_gst_total * GST_MULTIPLIER
+        return sum(entry.get("import_cost", 0) for entry in usage_data)
 
     def get_total_export_credit(self, property_id: str, service_type: str) -> float | None:
         """Get total export credit over period.
@@ -956,7 +969,7 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         return sum(entry.get("export_credit", 0) for entry in usage_data)
 
     def get_net_total_cost(self, property_id: str, service_type: str) -> float | None:
-        """Get net total cost (GST-inclusive import - export credit) over period."""
+        """Get net total cost (GST-exclusive import - export credit) over period."""
         import_cost = self.get_total_import_cost(property_id, service_type)
         export_credit = self.get_total_export_credit(property_id, service_type)
 
@@ -1007,9 +1020,9 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         return sum(entry.get("carbon_emission_tonne", 0) for entry in usage_data)
 
     def get_latest_import_cost(self, property_id: str, service_type: str) -> float | None:
-        """Get the most recent daily import cost, GST-inclusive (see get_total_import_cost)."""
+        """Get the most recent daily import cost, GST-exclusive (see get_total_import_cost)."""
         entry = self._get_latest_usage_entry(property_id, service_type)
-        return entry.get("import_cost", 0.0) * GST_MULTIPLIER if entry else None
+        return entry.get("import_cost", 0.0) if entry else None
 
     def get_latest_export_credit(self, property_id: str, service_type: str) -> float | None:
         """Get the most recent daily export credit."""

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.18.1"
+  "version": "1.19.0"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -52,6 +52,7 @@ from .const import (
     SENSOR_TYPE_PEAK_USAGE,
     SENSOR_TYPE_PRODUCT_NAME,
     SENSOR_TYPE_PROJECTED_CHARGES,
+    SENSOR_TYPE_PROJECTED_NET_COST,
     SENSOR_TYPE_RATE_PREFIX,
     SENSOR_TYPE_RECONSTRUCTED_IMPORT_COST,
     SENSOR_TYPE_SOLAR,
@@ -168,7 +169,9 @@ async def async_setup_entry(
                     RedEnergyCarbonEmissionSensor(coordinator, config_entry, account_id, service_type),
                     # NEW: Service/supply charge sensor
                     RedEnergyBillingPeriodServiceChargeSensor(coordinator, config_entry, account_id, service_type),
-                    # NEW: Projected charges (estimated, issue #75)
+                    # NEW: Projected net cost (energy only, issues #75, #77)
+                    RedEnergyProjectedNetCostSensor(coordinator, config_entry, account_id, service_type),
+                    # NEW: Projected charges (net cost + service charge, issue #77)
                     RedEnergyProjectedChargesSensor(coordinator, config_entry, account_id, service_type),
                 ])
 
@@ -949,12 +952,19 @@ class RedEnergyBillingPeriodServiceChargeSensor(RedEnergyBaseSensor):
         }
 
 
-class RedEnergyProjectedChargesSensor(RedEnergyBaseSensor):
-    """Red Energy projected charges sensor (issue #75).
+class RedEnergyProjectedNetCostSensor(RedEnergyBaseSensor):
+    """Red Energy projected net cost sensor (issues #75, #77).
 
-    Red Energy's API has no "projected charges" field - this is a linear
+    Red Energy's API has no bill-forecast field - this is a linear
     extrapolation of net cost-to-date across the full billing cycle
     (see coordinator.get_projected_charges), not Red Energy's own figure.
+    "Net cost" because it's energy only (import minus export credit) - it
+    excludes the daily service/supply charge, so it isn't a full bill
+    estimate. See RedEnergyProjectedChargesSensor for that. Distinct from
+    RedEnergyCostSensor ("Current Period Net Cost"), which is the actual
+    to-date figure, not a forecast - "Projected" is this sensor's
+    distinguisher, not "Current Period" (issue #78 already used that for
+    the actual-value sensors).
     state_class is intentionally left unset (not TOTAL/MEASUREMENT): this
     is a forward-looking estimate that can jump around as usage patterns
     change, not an accumulating total suitable for long-term statistics.
@@ -967,8 +977,8 @@ class RedEnergyProjectedChargesSensor(RedEnergyBaseSensor):
         property_id: str,
         service_type: str,
     ) -> None:
-        """Initialize the projected charges sensor."""
-        super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_PROJECTED_CHARGES)
+        """Initialize the projected net cost sensor."""
+        super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_PROJECTED_NET_COST)
 
         self._attr_device_class = SensorDeviceClass.MONETARY
         self._attr_native_unit_of_measurement = "AUD"
@@ -977,7 +987,7 @@ class RedEnergyProjectedChargesSensor(RedEnergyBaseSensor):
 
     @property
     def native_value(self) -> float | None:
-        """Return the estimated total charge for the current billing cycle."""
+        """Return the projected net energy cost for the current billing cycle."""
         result = self.coordinator.get_projected_charges(self._property_id, self._service_type)
         return round(result["projected_charges"], 2) if result is not None else None
 
@@ -993,6 +1003,56 @@ class RedEnergyProjectedChargesSensor(RedEnergyBaseSensor):
             "days_elapsed": result["days_elapsed"],
             "days_in_cycle": result["days_in_cycle"],
             "estimation_method": "linear",
+            "gst_basis": "inclusive",
+        }
+
+
+class RedEnergyProjectedChargesSensor(RedEnergyBaseSensor):
+    """Red Energy projected charges sensor (issue #77).
+
+    Projected net energy cost (see RedEnergyProjectedNetCostSensor) plus
+    the daily service/supply charge projected across the full billing
+    cycle, giving a fuller bill estimate. Unavailable when the plan has no
+    daily service-charge rate, or when the underlying net-cost projection
+    itself is unavailable (see coordinator.get_estimated_current_period_charges).
+    Both components are GST-inclusive.
+    """
+
+    def __init__(
+        self,
+        coordinator: RedEnergyDataCoordinator,
+        config_entry: ConfigEntry,
+        property_id: str,
+        service_type: str,
+    ) -> None:
+        """Initialize the projected charges sensor."""
+        super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_PROJECTED_CHARGES)
+
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_native_unit_of_measurement = "AUD"
+        self._attr_state_class = None
+        self._attr_icon = "mdi:receipt-text-clock"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the estimated total bill charge for the current billing cycle."""
+        result = self.coordinator.get_estimated_current_period_charges(self._property_id, self._service_type)
+        return round(result["estimated_charges"], 2) if result is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return the inputs used to derive the estimate."""
+        result = self.coordinator.get_estimated_current_period_charges(self._property_id, self._service_type)
+        if result is None:
+            return None
+
+        return {
+            "estimated_net_cost": round(result["estimated_net_cost"], 2),
+            "estimated_service_charge": round(result["estimated_service_charge"], 2),
+            "days_in_cycle": result["days_in_cycle"],
+            "service_rate_incl_gst": result["service_rate_incl_gst"],
+            "estimation_method": "linear",
+            "gst_basis": "inclusive",
         }
 
 

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -388,6 +388,7 @@ class RedEnergyCostSensor(RedEnergyBaseSensor):
             "last_updated": service_data.get("last_updated"),
             "service_type": self._service_type,
             "period": self._get_period_description(),
+            "gst_basis": "exclusive",
         }
 
 
@@ -1631,7 +1632,7 @@ class RedEnergyTotalImportCostSensor(RedEnergyBaseSensor):
             "last_updated": service_data.get("last_updated"),
             "service_type": self._service_type,
             "period": self._get_period_description(),
-            "gst_inclusive": False,
+            "gst_basis": "exclusive",
             "description": "Total cost of grid import"
         }
 
@@ -1723,7 +1724,7 @@ class RedEnergyDailyImportCostSensor(RedEnergyBaseSensor):
             "last_updated": service_data.get("last_updated"),
             "usage_date": self.coordinator.get_latest_usage_date(self._property_id, self._service_type),
             "service_type": self._service_type,
-            "gst_inclusive": False,
+            "gst_basis": "exclusive",
             "description": "Cost of grid import for latest day"
         }
 

--- a/tests/test_config_migration_v10.py
+++ b/tests/test_config_migration_v10.py
@@ -146,8 +146,12 @@ async def test_already_renamed_entity_is_a_noop():
     mock_entity_registry.async_update_entity.assert_not_called()
 
 
-def test_config_version_10_is_current():
-    assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_10
+def test_config_version_10_value():
+    """CONFIG_VERSION_10 == 10 is a fixed historical fact, independent of
+    whichever version is CURRENT_CONFIG_VERSION today. The "is this the
+    current version" and "does ConfigFlow.VERSION match" checks belong to
+    whichever migration test file introduced the latest version - see
+    test_config_migration_v11.py."""
     assert CONFIG_VERSION_10 == 10
 
 
@@ -162,13 +166,3 @@ def test_sensor_type_renames_v10_covers_all_total_sensors():
         "total_import_cost": "current_period_import_cost",
         "total_export_credit": "current_period_export_credit",
     }
-
-
-def test_config_flow_version_matches_current_config_version():
-    """Home Assistant core only calls async_migrate_entry when
-    ConfigEntry.version != ConfigFlow.VERSION - if these two drift apart,
-    every migration in this file becomes dead code for existing entries,
-    regardless of how correct the migration logic itself is."""
-    from custom_components.red_energy.config_flow import ConfigFlow
-
-    assert ConfigFlow.VERSION == CURRENT_CONFIG_VERSION

--- a/tests/test_config_migration_v11.py
+++ b/tests/test_config_migration_v11.py
@@ -1,0 +1,153 @@
+"""Test config migration to v11 - rename Projected Charges to Projected
+Net Cost.
+
+The original "Projected Charges" sensor (issue #75) didn't disclose that
+it's energy-only (it excludes the daily service/supply charge, see the
+new "Projected Charges" sensor that replaces it and includes the service
+charge, issue #77). This migration renames the old sensor's sensor_type
+suffix to "projected_net_cost" so existing entities keep their
+history/statistics rather than going stale and being recreated under a
+new entity_id.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.red_energy.config_migration import (
+    CONFIG_VERSION_11,
+    CURRENT_CONFIG_VERSION,
+    RedEnergyConfigMigrator,
+    SENSOR_TYPE_RENAMES_V11,
+)
+from custom_components.red_energy.const import DOMAIN
+
+
+def _make_config_entry(version=10):
+    entry = MagicMock()
+    entry.version = version
+    entry.entry_id = "entry1"
+    entry.data = {
+        "username": "test@example.com",
+        "password": "testpass",
+        "selected_accounts": ["1000001"],
+        "services": ["electricity", "gas"],
+    }
+    return entry
+
+
+def _registry_entry(entity_id, unique_id):
+    entry = MagicMock()
+    entry.entity_id = entity_id
+    entry.unique_id = unique_id
+    entry.platform = DOMAIN
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_renames_projected_charges_unique_id():
+    entry = _make_config_entry(version=10)
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    registry_entries = [
+        _registry_entry(
+            "sensor.entity_0", "red_energy_entry1_1000001_electricity_projected_charges"
+        )
+    ]
+
+    mock_entity_registry = MagicMock()
+    mock_entity_registry.async_update_entity = MagicMock()
+
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get", return_value=mock_entity_registry
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_config_entry",
+        return_value=registry_entries,
+    ):
+        migrator = RedEnergyConfigMigrator(hass)
+        result = await migrator.async_migrate_config_entry(entry)
+
+    assert result is True
+
+    mock_entity_registry.async_update_entity.assert_called_once_with(
+        "sensor.entity_0",
+        new_unique_id="red_energy_entry1_1000001_electricity_projected_net_cost",
+    )
+
+    hass.config_entries.async_update_entry.assert_any_call(entry, version=CURRENT_CONFIG_VERSION)
+
+
+@pytest.mark.asyncio
+async def test_entities_with_non_matching_sensor_type_are_untouched():
+    entry = _make_config_entry(version=10)
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    unrelated_entry = _registry_entry(
+        "sensor.daily_import", "red_energy_entry1_1000001_electricity_daily_import_usage"
+    )
+
+    mock_entity_registry = MagicMock()
+    mock_entity_registry.async_update_entity = MagicMock()
+
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get", return_value=mock_entity_registry
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_config_entry",
+        return_value=[unrelated_entry],
+    ):
+        migrator = RedEnergyConfigMigrator(hass)
+        result = await migrator._migrate_v10_to_v11(entry)
+
+    assert result is True
+    mock_entity_registry.async_update_entity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_already_renamed_entity_is_a_noop():
+    entry = _make_config_entry(version=10)
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    already_renamed = _registry_entry(
+        "sensor.entity_0",
+        "red_energy_entry1_1000001_electricity_projected_net_cost",
+    )
+
+    mock_entity_registry = MagicMock()
+    mock_entity_registry.async_update_entity = MagicMock()
+
+    with patch(
+        "homeassistant.helpers.entity_registry.async_get", return_value=mock_entity_registry
+    ), patch(
+        "homeassistant.helpers.entity_registry.async_entries_for_config_entry",
+        return_value=[already_renamed],
+    ):
+        migrator = RedEnergyConfigMigrator(hass)
+        result = await migrator._migrate_v10_to_v11(entry)
+
+    assert result is True
+    mock_entity_registry.async_update_entity.assert_not_called()
+
+
+def test_config_version_11_is_current():
+    assert CURRENT_CONFIG_VERSION == CONFIG_VERSION_11
+    assert CONFIG_VERSION_11 == 11
+
+
+def test_sensor_type_renames_v11():
+    assert SENSOR_TYPE_RENAMES_V11 == {
+        "projected_charges": "projected_net_cost",
+    }
+
+
+def test_config_flow_version_matches_current_config_version():
+    """Home Assistant core only calls async_migrate_entry when
+    ConfigEntry.version != ConfigFlow.VERSION - if these two drift apart,
+    every migration in this file becomes dead code for existing entries,
+    regardless of how correct the migration logic itself is."""
+    from custom_components.red_energy.config_flow import ConfigFlow
+
+    assert ConfigFlow.VERSION == CURRENT_CONFIG_VERSION

--- a/tests/test_gst_basis.py
+++ b/tests/test_gst_basis.py
@@ -1,0 +1,142 @@
+"""Tests for GST basis of the current/daily import cost sensors.
+
+Red Energy's consumptionDollar (-> import_cost) is ex-GST at the API
+boundary. Current Period Import Cost, Current Period Net Cost, and Daily
+Import Cost report this figure as-is (GST-exclusive) and disclose that
+via a "gst_basis" attribute, rather than uplifting it - unlike the
+forward-looking Projected Net Cost / Projected Charges sensors (see
+test_projected_charges.py), which are deliberately GST-inclusive.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.red_energy.coordinator import RedEnergyDataCoordinator
+from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY
+from custom_components.red_energy.sensor import (
+    RedEnergyCostSensor,
+    RedEnergyDailyImportCostSensor,
+    RedEnergyTotalImportCostSensor,
+)
+
+
+@pytest.fixture
+def mock_hass():
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock()
+    return hass
+
+
+@pytest.fixture
+def coordinator(mock_hass):
+    with patch(
+        "custom_components.red_energy.coordinator.async_get_clientsession",
+        return_value=MagicMock(),
+    ):
+        coord = RedEnergyDataCoordinator(
+            hass=mock_hass,
+            username="test_user",
+            password="test_pass",
+            selected_accounts=["2000002"],
+            services=["electricity"],
+        )
+    coord.api = AsyncMock()
+    coord.api._access_token = "test_token"
+    return coord
+
+
+def _set_coordinator_data(coordinator, usage_entries):
+    coordinator.data = {
+        "usage_data": {
+            "2000002": {
+                "property": {
+                    "name": "Test property",
+                    "address": {},
+                    "services": [
+                        {
+                            "type": SERVICE_TYPE_ELECTRICITY,
+                            "consumer_number": "elec-1",
+                            "meterType": "INTERVAL",
+                            "rates": [],
+                            "lastBillDate": "2025-07-25",
+                        }
+                    ],
+                },
+                "services": {
+                    SERVICE_TYPE_ELECTRICITY: {
+                        "consumer_number": "elec-1",
+                        "last_updated": "2025-08-01T10:00:00",
+                        "usage_data": {
+                            "from_date": "2025-07-26",
+                            "to_date": "2025-08-01",
+                            "usage_data": usage_entries,
+                        },
+                    }
+                },
+            },
+        }
+    }
+
+
+def _config_entry():
+    entry = MagicMock()
+    entry.entry_id = "entry1"
+    return entry
+
+
+class TestCoordinatorGstExclusive:
+    def test_get_total_import_cost_is_ex_gst(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [
+                {"date": "2025-07-31", "import_usage": 10.0, "import_cost": 10.0, "export_credit": 0.0},
+                {"date": "2025-08-01", "import_usage": 10.0, "import_cost": 25.0, "export_credit": 0.0},
+            ],
+        )
+        assert coordinator.get_total_import_cost("2000002", SERVICE_TYPE_ELECTRICITY) == pytest.approx(35.0)
+
+    def test_get_latest_import_cost_is_ex_gst(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [{"date": "2025-08-01", "import_usage": 10.0, "import_cost": 20.0, "export_credit": 0.0}],
+        )
+        assert coordinator.get_latest_import_cost("2000002", SERVICE_TYPE_ELECTRICITY) == pytest.approx(20.0)
+
+    def test_get_total_cost_is_ex_gst_net(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [{"date": "2025-08-01", "import_usage": 10.0, "import_cost": 20.0, "export_credit": 5.0}],
+        )
+        # No GST uplift here - 20.0 - 5.0 = 15.0, not (20.0*1.10) - 5.0
+        assert coordinator.get_total_cost("2000002", SERVICE_TYPE_ELECTRICITY) == pytest.approx(15.0)
+
+
+class TestSensorGstBasisAttribute:
+    def test_current_period_import_cost_discloses_exclusive(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [{"date": "2025-08-01", "import_usage": 10.0, "import_cost": 20.0, "export_credit": 0.0}],
+        )
+        sensor = RedEnergyTotalImportCostSensor(coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY)
+        assert sensor.native_value == pytest.approx(20.0)
+        assert sensor.extra_state_attributes["gst_basis"] == "exclusive"
+
+    def test_current_period_net_cost_discloses_exclusive(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [{"date": "2025-08-01", "import_usage": 10.0, "import_cost": 20.0, "export_credit": 5.0}],
+        )
+        sensor = RedEnergyCostSensor(coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY)
+        assert sensor.native_value == pytest.approx(15.0)
+        assert sensor.extra_state_attributes["gst_basis"] == "exclusive"
+
+    def test_daily_import_cost_discloses_exclusive(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [{"date": "2025-08-01", "import_usage": 10.0, "import_cost": 20.0, "export_credit": 0.0}],
+        )
+        sensor = RedEnergyDailyImportCostSensor(coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY)
+        assert sensor.native_value == pytest.approx(20.0)
+        assert sensor.extra_state_attributes["gst_basis"] == "exclusive"

--- a/tests/test_issue_62_fixes.py
+++ b/tests/test_issue_62_fixes.py
@@ -204,8 +204,7 @@ class TestLatestDaySelection:
 
         assert coordinator.get_latest_import_usage("prop-001", SERVICE_TYPE_ELECTRICITY) == 99.0
         assert coordinator.get_latest_export_usage("prop-001", SERVICE_TYPE_ELECTRICITY) == 9.0
-        # import_cost is GST-uplifted (x1.10) at the source; 20.0 ex-GST -> 22.0 inc-GST
-        assert coordinator.get_latest_import_cost("prop-001", SERVICE_TYPE_ELECTRICITY) == pytest.approx(22.0)
+        assert coordinator.get_latest_import_cost("prop-001", SERVICE_TYPE_ELECTRICITY) == 20.0
         assert coordinator.get_latest_export_credit("prop-001", SERVICE_TYPE_ELECTRICITY) == 2.0
         assert coordinator.get_latest_usage_date("prop-001", SERVICE_TYPE_ELECTRICITY) == "2024-01-15"
 

--- a/tests/test_issue_62_fixes.py
+++ b/tests/test_issue_62_fixes.py
@@ -204,7 +204,8 @@ class TestLatestDaySelection:
 
         assert coordinator.get_latest_import_usage("prop-001", SERVICE_TYPE_ELECTRICITY) == 99.0
         assert coordinator.get_latest_export_usage("prop-001", SERVICE_TYPE_ELECTRICITY) == 9.0
-        assert coordinator.get_latest_import_cost("prop-001", SERVICE_TYPE_ELECTRICITY) == 20.0
+        # import_cost is GST-uplifted (x1.10) at the source; 20.0 ex-GST -> 22.0 inc-GST
+        assert coordinator.get_latest_import_cost("prop-001", SERVICE_TYPE_ELECTRICITY) == pytest.approx(22.0)
         assert coordinator.get_latest_export_credit("prop-001", SERVICE_TYPE_ELECTRICITY) == 2.0
         assert coordinator.get_latest_usage_date("prop-001", SERVICE_TYPE_ELECTRICITY) == "2024-01-15"
 

--- a/tests/test_projected_charges.py
+++ b/tests/test_projected_charges.py
@@ -1,12 +1,26 @@
-"""Tests for the Projected Charges sensor (issue #75).
+"""Tests for the Projected Net Cost / Projected Charges sensors
+(issues #75, #77, and the #70 follow-up comment).
 
-Projected charges is not a value the Red Energy API exposes anywhere -
-unlike the billing period service charge (issue #71), which is derived
-from a real rate the API does return. This is a linear extrapolation of
-net cost-to-date (import cost minus export credit) across the full
-billing cycle, so it must never be confused with an authoritative
-Red Energy figure - hence the "estimation_method" attribute on the
-sensor and the "estimated" framing throughout.
+Neither value is exposed by the Red Energy API - both are linear
+extrapolations built from usage/billing metadata the integration already
+has, so they must never be confused with an authoritative Red Energy
+figure - hence the "estimation_method" attribute on both sensors.
+
+Three corrections from the original #75 implementation are covered here:
+- GST: import_cost (sourced from consumptionDollar) is ex-GST at the API
+  boundary; every cost/estimate/projection sensor must be GST-inclusive,
+  so get_total_import_cost/get_latest_import_cost uplift it by
+  GST_MULTIPLIER. export_credit (FIT/solar credit) has no GST component
+  and is never uplifted.
+- days_in_cycle off-by-one: nextBillDate is an exclusive boundary (first
+  day of the *next* cycle), symmetric with lastBillDate being excluded via
+  the +1 day in billing_period_start - using billing_period_start (not
+  raw lastBillDate) as the days_in_cycle anchor keeps both boundaries
+  treated the same way.
+- The original "Projected Charges" sensor is renamed to "Projected Net
+  Cost" to disclose it's energy-only (no service charge). A new
+  "Projected Charges" sensor takes its old name and adds the service
+  charge for a fuller bill estimate.
 """
 from __future__ import annotations
 
@@ -19,13 +33,27 @@ from custom_components.red_energy.coordinator import RedEnergyDataCoordinator
 from custom_components.red_energy.const import (
     CONF_ENABLE_ADVANCED_SENSORS,
     DOMAIN,
+    GST_MULTIPLIER,
     SERVICE_TYPE_ELECTRICITY,
     SERVICE_TYPE_GAS,
 )
 from custom_components.red_energy.sensor import (
     RedEnergyProjectedChargesSensor,
+    RedEnergyProjectedNetCostSensor,
     async_setup_entry,
 )
+
+SUPPLY_CHARGE_RATE = {
+    "rate_code": "80008279798F",
+    "rate_desc": "Service To Property",
+    "rate_incl_gst_dollars": 1.78145,
+    "type": "F",
+    "rate_excl_gst_cents": 161.95,
+    "discounted_rate_excl_gst_in_cents": 161.95,
+    "discounted_rate_incl_gst_in_cents": 178.145,
+    "unit": "Day",
+    "unit_step_desc": None,
+}
 
 
 @pytest.fixture
@@ -58,16 +86,18 @@ def _set_coordinator_data(
     usage_entries=None,
     last_bill_date=None,
     next_bill_date=None,
-    total_cost=None,
+    rates=None,
 ):
     """Build coordinator.data with both the property.services (metadata)
     and top-level services (usage) shapes get_service_metadata/get_service_usage
-    expect."""
+    expect. usage_entries carry raw import_cost/export_credit (ex-GST on
+    import) so get_total_import_cost's uplift is exercised end to end,
+    rather than pre-computing a "total_cost" the old fixture shape used."""
     service_metadata = {
         "type": SERVICE_TYPE_ELECTRICITY,
         "consumer_number": "elec-1",
         "meterType": "INTERVAL",
-        "rates": [],
+        "rates": rates or [],
     }
     if last_bill_date is not None:
         service_metadata["lastBillDate"] = last_bill_date
@@ -83,7 +113,6 @@ def _set_coordinator_data(
                 "from_date": "2024-01-01",
                 "to_date": "2024-01-30",
                 "usage_data": usage_entries,
-                "total_cost": total_cost if total_cost is not None else 0.0,
             },
         }
 
@@ -101,23 +130,43 @@ def _set_coordinator_data(
     }
 
 
+def _entry(date, import_cost, export_credit=0.0):
+    return {"date": date, "import_usage": 10.0, "import_cost": import_cost, "export_credit": export_credit}
+
+
 class TestGetProjectedCharges:
     def test_seven_day_period_extrapolates_to_full_cycle(self, coordinator):
-        """7 days elapsed, $35 net cost so far, 28-day cycle -> $140 projected."""
+        """7 days elapsed, $35 ex-GST import cost so far (no export), 28-day
+        cycle -> GST-inclusive net cost extrapolated across 28 days."""
         _set_coordinator_data(
             coordinator,
-            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            usage_entries=[_entry("2025-08-01", 35.0)],
             last_bill_date="2025-07-25",
             next_bill_date="2025-08-22",
-            total_cost=35.0,
         )
         result = coordinator.get_projected_charges("2000002", SERVICE_TYPE_ELECTRICITY)
         # elapsed = 2025-07-26..2025-08-01 inclusive = 7 days
-        # cycle = 2025-07-25..2025-08-22 = 28 days
-        assert result["projected_charges"] == pytest.approx(35.0 / 7 * 28)
-        assert result["net_cost_to_date"] == pytest.approx(35.0)
+        # cycle = billing_period_start (2025-07-26) .. nextBillDate (2025-08-22) = 27 days
+        net_cost_to_date = 35.0 * GST_MULTIPLIER
+        assert result["net_cost_to_date"] == pytest.approx(net_cost_to_date)
         assert result["days_elapsed"] == 7
-        assert result["days_in_cycle"] == 28
+        assert result["days_in_cycle"] == 27
+        assert result["projected_charges"] == pytest.approx(net_cost_to_date / 7 * 27)
+
+    def test_days_in_cycle_excludes_next_bill_date_as_a_charge_day(self, coordinator):
+        """Reproduces the #70 follow-up comment's real-world case: cycle
+        26 Jul-25 Aug (31 charge days), latest usage 24 Aug (30 days
+        elapsed). nextBillDate (26 Aug) must not be counted as part of this
+        cycle - days_in_cycle must be 31, not 32."""
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2026-08-24", 300.0)],
+            last_bill_date="2026-07-25",
+            next_bill_date="2026-08-26",
+        )
+        result = coordinator.get_projected_charges("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result["days_in_cycle"] == 31
+        assert result["days_elapsed"] == 30
 
     def test_returns_none_when_no_usage_data(self, coordinator):
         _set_coordinator_data(
@@ -131,20 +180,18 @@ class TestGetProjectedCharges:
     def test_returns_none_when_next_bill_date_missing(self, coordinator):
         _set_coordinator_data(
             coordinator,
-            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            usage_entries=[_entry("2025-08-01", 35.0)],
             last_bill_date="2025-07-25",
             next_bill_date=None,
-            total_cost=35.0,
         )
         assert coordinator.get_projected_charges("2000002", SERVICE_TYPE_ELECTRICITY) is None
 
     def test_returns_none_when_next_bill_date_invalid(self, coordinator):
         _set_coordinator_data(
             coordinator,
-            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            usage_entries=[_entry("2025-08-01", 35.0)],
             last_bill_date="2025-07-25",
             next_bill_date="not-a-date",
-            total_cost=35.0,
         )
         assert coordinator.get_projected_charges("2000002", SERVICE_TYPE_ELECTRICITY) is None
 
@@ -152,10 +199,9 @@ class TestGetProjectedCharges:
         """A stale/inconsistent nextBillDate must not produce a zero or negative cycle length."""
         _set_coordinator_data(
             coordinator,
-            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            usage_entries=[_entry("2025-08-01", 35.0)],
             last_bill_date="2025-07-25",
-            next_bill_date="2025-07-25",
-            total_cost=35.0,
+            next_bill_date="2025-07-26",  # == billing_period_start, so days_in_cycle == 0
         )
         assert coordinator.get_projected_charges("2000002", SERVICE_TYPE_ELECTRICITY) is None
 
@@ -163,10 +209,9 @@ class TestGetProjectedCharges:
         """Stale/cached usage predating a just-rolled billing period must not produce a negative day count."""
         _set_coordinator_data(
             coordinator,
-            usage_entries=[{"date": "2025-07-20", "import_usage": 10.0}],
+            usage_entries=[_entry("2025-07-20", 35.0)],
             last_bill_date="2025-07-25",
             next_bill_date="2025-08-22",
-            total_cost=35.0,
         )
         assert coordinator.get_projected_charges("2000002", SERVICE_TYPE_ELECTRICITY) is None
 
@@ -174,14 +219,15 @@ class TestGetProjectedCharges:
         """lastBillDate + 1 == latest usageDate must count as exactly 1 day, not 0."""
         _set_coordinator_data(
             coordinator,
-            usage_entries=[{"date": "2025-07-26", "import_usage": 10.0}],
+            usage_entries=[_entry("2025-07-26", 5.0)],
             last_bill_date="2025-07-25",
             next_bill_date="2025-08-22",
-            total_cost=5.0,
         )
         result = coordinator.get_projected_charges("2000002", SERVICE_TYPE_ELECTRICITY)
-        # elapsed = 1 day, cycle = 28 days
-        assert result["projected_charges"] == pytest.approx(5.0 / 1 * 28)
+        assert result["days_elapsed"] == 1
+        assert result["days_in_cycle"] == 27
+        net_cost_to_date = 5.0 * GST_MULTIPLIER
+        assert result["projected_charges"] == pytest.approx(net_cost_to_date / 1 * 27)
 
     def test_falls_back_to_30_day_period_when_last_bill_date_missing(self, coordinator):
         today = datetime.now()
@@ -189,30 +235,71 @@ class TestGetProjectedCharges:
         next_bill_date = (today + timedelta(days=5)).strftime("%Y-%m-%d")
         _set_coordinator_data(
             coordinator,
-            usage_entries=[{"date": latest_usage_date, "import_usage": 10.0}],
+            usage_entries=[_entry(latest_usage_date, 60.0)],
             last_bill_date=None,
             next_bill_date=next_bill_date,
-            total_cost=60.0,
         )
-        # billing_period_start falls back to (today - 30 days); nextBillDate
-        # is still used verbatim as the cycle end even though lastBillDate
-        # (the true cycle start metadata field) is missing.
         result = coordinator.get_projected_charges("2000002", SERVICE_TYPE_ELECTRICITY)
         assert result is not None
 
     def test_uses_net_cost_not_gross(self, coordinator):
-        """total_cost already reflects import minus export credit
-        (see data_validation.py aggregation of the per-day "cost" field) -
-        the projection must use it as-is, not re-derive a gross figure."""
+        """Export credit reduces the GST-inclusive import cost; the
+        projection must reflect that net figure, not gross import alone."""
         _set_coordinator_data(
             coordinator,
-            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            usage_entries=[_entry("2025-08-01", 5.0, export_credit=10.0)],
             last_bill_date="2025-07-25",
             next_bill_date="2025-08-22",
-            total_cost=-2.0,  # net exporter/credit for the period so far
         )
         result = coordinator.get_projected_charges("2000002", SERVICE_TYPE_ELECTRICITY)
-        assert result["projected_charges"] == pytest.approx(-2.0 / 7 * 28)
+        net_cost_to_date = 5.0 * GST_MULTIPLIER - 10.0
+        assert net_cost_to_date < 0  # net exporter/credit for the period so far
+        assert result["net_cost_to_date"] == pytest.approx(net_cost_to_date)
+        assert result["projected_charges"] == pytest.approx(net_cost_to_date / 7 * 27)
+
+
+class TestGetEstimatedCurrentPeriodCharges:
+    def test_adds_service_charge_projected_across_full_cycle(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2025-08-01", 35.0)],
+            last_bill_date="2025-07-25",
+            next_bill_date="2025-08-22",
+            rates=[SUPPLY_CHARGE_RATE],
+        )
+        result = coordinator.get_estimated_current_period_charges("2000002", SERVICE_TYPE_ELECTRICITY)
+
+        net_cost_to_date = 35.0 * GST_MULTIPLIER
+        expected_net_projection = net_cost_to_date / 7 * 27
+        expected_service_charge = SUPPLY_CHARGE_RATE["rate_incl_gst_dollars"] * 27
+
+        assert result["days_in_cycle"] == 27
+        assert result["estimated_net_cost"] == pytest.approx(expected_net_projection)
+        assert result["estimated_service_charge"] == pytest.approx(expected_service_charge)
+        assert result["estimated_charges"] == pytest.approx(expected_net_projection + expected_service_charge)
+        assert result["service_rate_incl_gst"] == pytest.approx(SUPPLY_CHARGE_RATE["rate_incl_gst_dollars"])
+
+    def test_returns_none_when_no_service_charge_rate(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2025-08-01", 35.0)],
+            last_bill_date="2025-07-25",
+            next_bill_date="2025-08-22",
+            rates=[],
+        )
+        assert coordinator.get_estimated_current_period_charges("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_returns_none_when_projection_unavailable(self, coordinator):
+        """No rate for the service charge, and separately, no usable
+        projection (missing nextBillDate) - either alone must return None."""
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2025-08-01", 35.0)],
+            last_bill_date="2025-07-25",
+            next_bill_date=None,
+            rates=[SUPPLY_CHARGE_RATE],
+        )
+        assert coordinator.get_estimated_current_period_charges("2000002", SERVICE_TYPE_ELECTRICITY) is None
 
 
 from homeassistant.components.sensor import SensorDeviceClass
@@ -224,35 +311,78 @@ def _config_entry():
     return entry
 
 
-class TestProjectedChargesSensor:
+class TestProjectedNetCostSensor:
     def test_native_value_and_attributes(self, coordinator):
         _set_coordinator_data(
             coordinator,
-            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            usage_entries=[_entry("2025-08-01", 35.0)],
             last_bill_date="2025-07-25",
             next_bill_date="2025-08-22",
-            total_cost=35.0,
         )
-        sensor = RedEnergyProjectedChargesSensor(
+        sensor = RedEnergyProjectedNetCostSensor(
             coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
         )
-        assert sensor.native_value == pytest.approx(35.0 / 7 * 28)
+        net_cost_to_date = 35.0 * GST_MULTIPLIER
+        assert sensor.native_value == pytest.approx(net_cost_to_date / 7 * 27, abs=0.01)
         assert sensor.device_class == SensorDeviceClass.MONETARY
         assert sensor.native_unit_of_measurement == "AUD"
         assert sensor.state_class is None
 
         attrs = sensor.extra_state_attributes
-        assert attrs["net_cost_to_date"] == pytest.approx(35.0)
+        assert attrs["net_cost_to_date"] == pytest.approx(net_cost_to_date)
         assert attrs["days_elapsed"] == 7
-        assert attrs["days_in_cycle"] == 28
-        assert attrs["estimation_method"] == "linear"
+        assert attrs["days_in_cycle"] == 27
+        assert attrs["gst_basis"] == "inclusive"
 
     def test_native_value_none_when_next_bill_date_missing(self, coordinator):
         _set_coordinator_data(
             coordinator,
-            usage_entries=[{"date": "2025-08-01", "import_usage": 10.0}],
+            usage_entries=[_entry("2025-08-01", 35.0)],
             last_bill_date="2025-07-25",
-            total_cost=35.0,
+        )
+        sensor = RedEnergyProjectedNetCostSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes is None
+
+
+class TestProjectedChargesSensor:
+    def test_native_value_and_attributes(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2025-08-01", 35.0)],
+            last_bill_date="2025-07-25",
+            next_bill_date="2025-08-22",
+            rates=[SUPPLY_CHARGE_RATE],
+        )
+        sensor = RedEnergyProjectedChargesSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+
+        net_cost_to_date = 35.0 * GST_MULTIPLIER
+        expected_net_projection = net_cost_to_date / 7 * 27
+        expected_service_charge = SUPPLY_CHARGE_RATE["rate_incl_gst_dollars"] * 27
+
+        assert sensor.native_value == pytest.approx(
+            expected_net_projection + expected_service_charge, abs=0.01
+        )
+        assert sensor.device_class == SensorDeviceClass.MONETARY
+        assert sensor.native_unit_of_measurement == "AUD"
+        assert sensor.state_class is None
+
+        attrs = sensor.extra_state_attributes
+        assert attrs["days_in_cycle"] == 27
+        assert attrs["gst_basis"] == "inclusive"
+        assert attrs["service_rate_incl_gst"] == pytest.approx(SUPPLY_CHARGE_RATE["rate_incl_gst_dollars"])
+
+    def test_native_value_none_when_no_service_charge_rate(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2025-08-01", 35.0)],
+            last_bill_date="2025-07-25",
+            next_bill_date="2025-08-22",
+            rates=[],
         )
         sensor = RedEnergyProjectedChargesSensor(
             coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
@@ -296,7 +426,7 @@ def _mock_coordinator_for_setup(service_type=SERVICE_TYPE_ELECTRICITY, property_
 
 
 @pytest.mark.asyncio
-async def test_projected_charges_sensor_not_created_when_advanced_disabled():
+async def test_projected_sensors_not_created_when_advanced_disabled():
     coordinator = _mock_coordinator_for_setup()
     config_entry = MagicMock()
     config_entry.entry_id = "entry1"
@@ -317,14 +447,12 @@ async def test_projected_charges_sensor_not_created_when_advanced_disabled():
     async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
     await async_setup_entry(hass, config_entry, async_add_entities)
 
-    projected_sensors = [
-        e for e in added_entities if isinstance(e, RedEnergyProjectedChargesSensor)
-    ]
-    assert projected_sensors == []
+    assert not [e for e in added_entities if isinstance(e, RedEnergyProjectedNetCostSensor)]
+    assert not [e for e in added_entities if isinstance(e, RedEnergyProjectedChargesSensor)]
 
 
 @pytest.mark.asyncio
-async def test_projected_charges_sensor_created_for_electricity_and_gas_when_advanced_enabled():
+async def test_projected_sensors_created_for_electricity_and_gas_when_advanced_enabled():
     coordinator = _mock_coordinator_for_setup(service_type=SERVICE_TYPE_ELECTRICITY)
     gas_coordinator_data = coordinator.data["usage_data"]["2000002"]["property"]["services"]
     gas_coordinator_data.append({**gas_coordinator_data[0], "type": SERVICE_TYPE_GAS})
@@ -348,7 +476,11 @@ async def test_projected_charges_sensor_created_for_electricity_and_gas_when_adv
     async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
     await async_setup_entry(hass, config_entry, async_add_entities)
 
-    projected_sensors = [
+    net_cost_sensors = [
+        e for e in added_entities if isinstance(e, RedEnergyProjectedNetCostSensor)
+    ]
+    charges_sensors = [
         e for e in added_entities if isinstance(e, RedEnergyProjectedChargesSensor)
     ]
-    assert len(projected_sensors) == 2
+    assert len(net_cost_sensors) == 2
+    assert len(charges_sensors) == 2


### PR DESCRIPTION
## Summary
- **GST fix**: `import_cost` (sourced from Red Energy's `consumptionDollar`) is ex-GST at the API boundary - `get_total_import_cost`/`get_latest_import_cost` now uplift it by 10%, so every cost/estimate/projection sensor (Daily/Current Period Import Cost, Current Period Net Cost, and the projection sensors below) is consistently GST-inclusive. `export_credit` (FIT/solar credit) has no GST component and is unchanged.
- **days_in_cycle off-by-one fix** (#70 follow-up comment): `nextBillDate` is an exclusive boundary (first day of the *next* cycle) - using `billing_period_start` instead of raw `lastBillDate` as the cycle-length anchor keeps both boundaries treated symmetrically. Previously overstated projections by one day's cost.
- **Rename**: the original `Projected Charges` sensor (#75) is renamed to `Projected Net Cost`, to disclose it's energy-only (no service charge) - addresses #77.
- **New sensor**: `Projected Charges` = `Projected Net Cost` + daily service/supply charge projected across the full cycle, for a fuller bill estimate - also addresses #77.

## Migration
- New config versions 10->11: renames `projected_charges` -> `projected_net_cost` in place via the entity registry, so history/Energy Dashboard statistics carry over.

## Related
Addresses #70 (follow-up comment) and #77.