### PR TITLE
fix: cap usage window at nextBillDate during rollover lag

### DIFF
--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -114,8 +114,34 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         return start_date
 
     def _get_usage_period_dates(self, service: dict[str, Any]) -> tuple[datetime, datetime]:
+        """Resolve the usage query window, capped at the current cycle's exclusive end.
+
+        end_date defaults to now, but while lastBillDate/nextBillDate still
+        describe a completed cycle (Red Energy typically takes a few days to
+        roll billing metadata forward after the cycle actually ends - issue
+        #81), the window must not extend into the next cycle just because
+        time has passed and new usageDate entries exist. nextBillDate is the
+        exclusive start of the next cycle, so the cap is nextBillDate minus
+        one day. A missing/invalid nextBillDate leaves end_date uncapped -
+        there's no sane fallback boundary, matching _get_billing_period_start's
+        handling of a missing lastBillDate.
+        """
         end_date = datetime.now()
         start_date = self._get_billing_period_start(service)
+
+        next_bill_date_str = service.get("nextBillDate")
+        if next_bill_date_str:
+            try:
+                next_bill_date = datetime.strptime(next_bill_date_str, "%Y-%m-%d")
+                cycle_end_cap = next_bill_date - timedelta(days=1)
+                if cycle_end_cap < end_date:
+                    end_date = cycle_end_cap
+            except (ValueError, TypeError) as err:
+                _LOGGER.warning("Invalid nextBillDate format '%s': %s, not capping usage window", next_bill_date_str, err)
+
+        if end_date < start_date:
+            end_date = start_date
+
         return start_date, end_date
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.19.0"
+  "version": "1.19.1"
 }

--- a/tests/test_issue_62_fixes.py
+++ b/tests/test_issue_62_fixes.py
@@ -188,6 +188,71 @@ class TestBillingPeriodBoundary:
         assert (datetime.now() - start).days == 30
 
 
+class TestUsagePeriodEndCappedByNextBillDate:
+    """Issue #81: while billing metadata is stale, the usage query window must
+    not extend past the current cycle's exclusive nextBillDate boundary, even
+    though real time (and newly published usageDate entries) keep moving on."""
+
+    def test_end_date_capped_when_next_bill_date_has_passed(self, coordinator):
+        last_bill_date = (datetime.now() - timedelta(days=35)).strftime("%Y-%m-%d")
+        next_bill_date = (datetime.now() - timedelta(days=3)).strftime("%Y-%m-%d")
+        service = {"lastBillDate": last_bill_date, "nextBillDate": next_bill_date}
+
+        _start_date, end_date = coordinator._get_usage_period_dates(service)
+
+        expected_end = datetime.strptime(next_bill_date, "%Y-%m-%d") - timedelta(days=1)
+        assert end_date.date() == expected_end.date()
+
+    def test_end_date_not_capped_when_next_bill_date_in_future(self, coordinator):
+        last_bill_date = (datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d")
+        next_bill_date = (datetime.now() + timedelta(days=10)).strftime("%Y-%m-%d")
+        service = {"lastBillDate": last_bill_date, "nextBillDate": next_bill_date}
+
+        _start_date, end_date = coordinator._get_usage_period_dates(service)
+
+        assert end_date.date() == datetime.now().date()
+
+    def test_end_date_uncapped_when_next_bill_date_missing(self, coordinator):
+        last_bill_date = (datetime.now() - timedelta(days=35)).strftime("%Y-%m-%d")
+        service = {"lastBillDate": last_bill_date}
+
+        _start_date, end_date = coordinator._get_usage_period_dates(service)
+
+        assert end_date.date() == datetime.now().date()
+
+    def test_end_date_uncapped_when_next_bill_date_invalid(self, coordinator):
+        last_bill_date = (datetime.now() - timedelta(days=35)).strftime("%Y-%m-%d")
+        service = {"lastBillDate": last_bill_date, "nextBillDate": "not-a-date"}
+
+        _start_date, end_date = coordinator._get_usage_period_dates(service)
+
+        assert end_date.date() == datetime.now().date()
+
+    def test_progressive_overrun_stays_bounded_across_multiple_days(self, coordinator):
+        """Regression check for the reporter's 31 -> 32 -> 33 day drift: the
+        represented period must stay pinned to nextBillDate - 1 day no matter
+        how many days pass while the metadata remains stale."""
+        last_bill_date = (datetime.now() - timedelta(days=34)).strftime("%Y-%m-%d")
+        next_bill_date = (datetime.now() - timedelta(days=2)).strftime("%Y-%m-%d")
+        service = {"lastBillDate": last_bill_date, "nextBillDate": next_bill_date}
+
+        start_date, end_date = coordinator._get_usage_period_dates(service)
+        represented_days = (end_date - start_date).days + 1
+
+        assert represented_days == 31
+
+    def test_end_date_never_precedes_start_date(self, coordinator):
+        """Defensive floor: an implausible nextBillDate before lastBillDate
+        must not produce an inverted (negative-length) query window."""
+        last_bill_date = (datetime.now() - timedelta(days=5)).strftime("%Y-%m-%d")
+        next_bill_date = (datetime.now() - timedelta(days=20)).strftime("%Y-%m-%d")
+        service = {"lastBillDate": last_bill_date, "nextBillDate": next_bill_date}
+
+        start_date, end_date = coordinator._get_usage_period_dates(service)
+
+        assert end_date >= start_date
+
+
 class TestLatestDaySelection:
     """Bug #5: latest-day values should be selected by max usageDate, not list position."""
 


### PR DESCRIPTION
## Summary
- `_get_usage_period_dates()` used `datetime.now()` unconditionally as the query end date, so Current Period sensors, the service charge, and projected charges kept growing past a completed billing cycle whenever Red's billing metadata lagged behind rollover (#81)
- Now caps the end date at `nextBillDate - 1 day` once that boundary has passed and metadata hasn't rolled forward yet; a missing/invalid `nextBillDate` leaves it uncapped, consistent with the existing `lastBillDate` fallback behavior
- Added tests for capped/uncapped/invalid cases and a regression check pinning the represented period at 31 days across the reporter's 31→32→33 day drift scenario

Addresses the primary boundary-overrun issue from #81. The secondary metadata-refresh-acceleration suggestion is intentionally not included — HA history confirms Red only publishes usage once daily, so more frequent metadata polling wouldn't help.