### PR TITLE
fix: rename Billing Period Service Charge to Current Period

### DIFF
--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.19.1"
+  "version": "1.19.2"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -903,6 +903,10 @@ class RedEnergyBillingPeriodServiceChargeSensor(RedEnergyBaseSensor):
         super().__init__(
             coordinator, config_entry, property_id, service_type, SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE
         )
+        # Named "Current Period" for consistency with the other current-cycle
+        # sensors (Current Period Import Usage, etc.) - unique_id is left on
+        # "billing_period_service_charge" for backward compatibility.
+        self._attr_name = "Current Period Service Charge"
 
         self._attr_device_class = SensorDeviceClass.MONETARY
         self._attr_native_unit_of_measurement = "AUD"

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -264,6 +264,8 @@ class TestBillingPeriodServiceChargeSensor:
         assert sensor.device_class == SensorDeviceClass.MONETARY
         assert sensor.native_unit_of_measurement == "AUD"
         assert sensor.state_class == SensorStateClass.TOTAL
+        assert sensor._attr_name == "Current Period Service Charge"
+        assert sensor._attr_unique_id.endswith("_billing_period_service_charge")
 
         attrs = sensor.extra_state_attributes
         assert attrs["billing_period_start"] == "2025-07-26"


### PR DESCRIPTION
## Summary
- Renames the "Billing Period Service Charge" sensor's display name to "Current Period Service Charge", matching the naming of its sibling current-cycle sensors (Current Period Import Usage, Current Period Import Cost, Current Period Export Credit, Current Period Net Cost)
- `unique_id` is unchanged (still ends `_billing_period_service_charge`) so existing entities/history/statistics are preserved - only the friendly name changes
- No other sensor names need alignment: everything else (Projected Net Cost/Charges, Daily *, Peak/Offpeak/Shoulder *, metadata sensors) uses its own distinct naming that doesn't overlap with the "period" terminology