### PR TITLE
fix: rename Account Balance, remove Max Demand Interval Start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ The `/usage/interval` endpoint returns an **array of daily summaries**, each wit
 Two tiers of sensors per service (electricity or gas) per property:
 
 - **Core sensors** (22 per service, always created): daily/total import/export usage and cost, account metadata, billing dates
-- **Advanced sensors** (13 per service, optional toggle): time-of-use breakdown (peak/offpeak/shoulder), peak demand, carbon emissions
+- **Advanced sensors** (12 for electricity, 3 for gas, optional toggle): time-of-use breakdown (peak/offpeak/shoulder), peak demand, carbon emissions
 
 Unique IDs follow the pattern: `{domain}_{entry_id}_{property_id}_{service_type}_{sensor_type}`
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Since electricity-only concepts (solar, export, time-of-use tariffs, demand, car
 One diagnostic sensor per rate on the account's actual plan (e.g. Peak, Off-Peak, Shoulder, Supply, Demand, or tiered gas usage steps), named `Rate {rate description}`. The state is the rate in dollars including GST; unit, excl-GST rate, and step description are exposed as attributes. The number of these sensors depends entirely on the plan's tariff structure.
 
 ### Advanced Sensors (Optional)
-Enabled via the "Advanced Sensors" integration option. **13 sensors for electricity accounts, 3 for gas accounts** (gas accounts only get Daily/Monthly Average and Peak Usage, which apply to total usage regardless of service):
+Enabled via the "Advanced Sensors" integration option. **12 sensors for electricity accounts, 3 for gas accounts** (gas accounts only get Daily/Monthly Average and Peak Usage, which apply to total usage regardless of service):
 
 **Statistical Analysis:**
 - Daily Average - Average daily usage
@@ -137,7 +137,6 @@ Enabled via the "Advanced Sensors" integration option. **13 sensors for electric
 
 **Demand & Environmental** *(electricity only)*:
 - Max Demand - Maximum demand (kW)
-- Max Demand Interval Start - Time of maximum demand *(disabled by default - enable manually if useful)*
 - Carbon Emission Tonne - Carbon emissions (tonnes CO₂e)
 
 ### Diagnostics Button

--- a/custom_components/red_energy/const.py
+++ b/custom_components/red_energy/const.py
@@ -65,7 +65,6 @@ SENSOR_TYPE_SHOULDER_EXPORT_USAGE: Final = "shoulder_export_usage"
 
 # Breakdown sensor types - Demand and environmental (ADVANCED)
 SENSOR_TYPE_MAX_DEMAND: Final = "max_demand"
-SENSOR_TYPE_MAX_DEMAND_TIME: Final = "max_demand_interval_start"
 SENSOR_TYPE_CARBON_EMISSION: Final = "carbon_emission_tonne"
 
 # CL2 (Controlled Load 2) / TOU inference sensors - only created for

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.19.2"
+  "version": "1.19.3"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -165,7 +165,6 @@ async def async_setup_entry(
                     RedEnergyShoulderExportUsageSensor(coordinator, config_entry, account_id, service_type),
                     # NEW: Demand and environmental (ADVANCED)
                     RedEnergyMaxDemandSensor(coordinator, config_entry, account_id, service_type),
-                    RedEnergyMaxDemandTimeSensor(coordinator, config_entry, account_id, service_type),
                     RedEnergyCarbonEmissionSensor(coordinator, config_entry, account_id, service_type),
                     # NEW: Service/supply charge sensor
                     RedEnergyBillingPeriodServiceChargeSensor(coordinator, config_entry, account_id, service_type),
@@ -1128,7 +1127,9 @@ class RedEnergyBalanceSensor(RedEnergyBaseSensor):
     ) -> None:
         """Initialize the balance sensor."""
         super().__init__(coordinator, config_entry, property_id, service_type, SENSOR_TYPE_BALANCE)
-        
+        # unique_id stays on "balance" for backward compatibility.
+        self._attr_name = "Account Balance"
+
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_device_class = SensorDeviceClass.MONETARY
         self._attr_native_unit_of_measurement = "AUD"
@@ -2083,41 +2084,6 @@ class RedEnergyMaxDemandSensor(RedEnergyBaseSensor):
             "max_demand_date": data.get("max_demand_date"),
             "period": self._get_period_description()
         }
-
-
-class RedEnergyMaxDemandTimeSensor(RedEnergyBaseSensor):
-    """Red Energy maximum demand timestamp sensor."""
-
-    _electricity_only = True
-
-    def __init__(
-        self,
-        coordinator: RedEnergyDataCoordinator,
-        config_entry: ConfigEntry,
-        property_id: str,
-        service_type: str,
-    ) -> None:
-        """Initialize the maximum demand timestamp sensor."""
-        super().__init__(coordinator, config_entry, property_id, service_type, "max_demand_interval_start")
-
-        self._attr_device_class = SensorDeviceClass.TIMESTAMP
-        self._attr_icon = "mdi:clock-alert"
-        # Rarely useful on its own (the value it timestamps - max demand -
-        # is the primary sensor) and often has no value even when usage data
-        # exists, so it's disabled by default rather than always enabled.
-        self._attr_entity_registry_enabled_default = False
-
-    @property
-    def native_value(self) -> datetime | None:
-        """Return the maximum demand timestamp."""
-        data = self.coordinator.get_max_demand_data(self._property_id, self._service_type)
-        if not data or not data.get("max_demand_time"):
-            return None
-        
-        try:
-            return datetime.fromisoformat(data["max_demand_time"])
-        except (ValueError, TypeError):
-            return None
 
 
 class RedEnergyCarbonEmissionSensor(RedEnergyBaseSensor):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -28,6 +28,7 @@ from custom_components.red_energy.sensor import (
     RedEnergyNmiSensor,
     RedEnergyMeterTypeSensor,
     RedEnergySolarSensor,
+    RedEnergyBalanceSensor,
     RedEnergyDailyImportUsageSensor,
     RedEnergyDailyExportUsageSensor,
     RedEnergyTotalImportUsageSensor,
@@ -38,7 +39,6 @@ from custom_components.red_energy.sensor import (
     RedEnergyOffpeakImportUsageSensor,
     RedEnergyShoulderImportUsageSensor,
     RedEnergyMaxDemandSensor,
-    RedEnergyMaxDemandTimeSensor,
 )
 
 
@@ -343,8 +343,18 @@ class TestMetadataSensors:
         config_entry = create_mock_config_entry()
         
         sensor = RedEnergySolarSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        
+
         assert sensor.native_value == "Yes"
+
+    def test_balance_sensor_name(self):
+        """Test balance sensor is named 'Account Balance', unprefixed by service type."""
+        coordinator = create_mock_coordinator()
+        config_entry = create_mock_config_entry()
+
+        sensor = RedEnergyBalanceSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
+
+        assert sensor._attr_name == "Account Balance"
+        assert sensor._attr_unique_id.endswith("_balance")
 
 
 class TestImportExportSensors:
@@ -621,85 +631,21 @@ class TestMaxDemandSensors:
         
         sensor = RedEnergyMaxDemandSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
         attributes = sensor.extra_state_attributes
-        
+
         assert attributes is None
 
-    def test_max_demand_time_sensor_basic_properties(self):
-        """Test max demand time sensor basic properties."""
+    def test_max_demand_sensor_with_real_api_data(self):
+        """Test max demand sensor with real API data structure from debug logs."""
         coordinator = create_mock_coordinator()
         config_entry = create_mock_config_entry()
-        
-        sensor = RedEnergyMaxDemandTimeSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        
-        assert sensor.device_class == SensorDeviceClass.TIMESTAMP
-        assert sensor.icon == "mdi:clock-alert"
 
-    def test_max_demand_time_sensor_value(self):
-        """Test max demand time sensor returns correct datetime value."""
-        coordinator = create_mock_coordinator()
-        config_entry = create_mock_config_entry()
-        
-        sensor = RedEnergyMaxDemandTimeSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        
-        # Test with valid datetime string
-        from datetime import datetime
-        expected_time = datetime.fromisoformat("2024-01-15T18:30:00")
-        assert sensor.native_value == expected_time
-        
-        # Test with no data
-        coordinator.get_max_demand_data = MagicMock(return_value=None)
-        sensor = RedEnergyMaxDemandTimeSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        assert sensor.native_value is None
-
-    def test_max_demand_time_sensor_invalid_datetime(self):
-        """Test max demand time sensor handles invalid datetime strings."""
-        coordinator = create_mock_coordinator()
-        config_entry = create_mock_config_entry()
-        
-        # Test with invalid datetime string
-        coordinator.get_max_demand_data = MagicMock(return_value={
-            "max_demand_kw": 5.2,
-            "max_demand_time": "invalid-datetime",
-            "max_demand_date": "2024-01-15"
-        })
-        
-        sensor = RedEnergyMaxDemandTimeSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        assert sensor.native_value is None
-
-    def test_max_demand_time_sensor_no_time_data(self):
-        """Test max demand time sensor when max_demand_time is None."""
-        coordinator = create_mock_coordinator()
-        config_entry = create_mock_config_entry()
-        
-        # Test with no time data
-        coordinator.get_max_demand_data = MagicMock(return_value={
-            "max_demand_kw": 5.2,
-            "max_demand_time": None,
-            "max_demand_date": "2024-01-15"
-        })
-        
-        sensor = RedEnergyMaxDemandTimeSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        assert sensor.native_value is None
-
-    def test_max_demand_sensors_with_real_api_data(self):
-        """Test max demand sensors with real API data structure from debug logs."""
-        coordinator = create_mock_coordinator()
-        config_entry = create_mock_config_entry()
-        
         # Mock data based on the debug log structure
         coordinator.get_max_demand_data = MagicMock(return_value={
             "max_demand_kw": 0.014,
             "max_demand_time": "2025-10-10T16:30:00+10:00",
             "max_demand_date": "2025-10-10"
         })
-        
-        # Test max demand sensor
+
         max_demand_sensor = RedEnergyMaxDemandSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
         assert max_demand_sensor.native_value == 0.014
-        
-        # Test max demand time sensor
-        max_demand_time_sensor = RedEnergyMaxDemandTimeSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
-        from datetime import datetime
-        expected_time = datetime.fromisoformat("2025-10-10T16:30:00+10:00")
-        assert max_demand_time_sensor.native_value == expected_time
 

--- a/tests/test_sensor_electricity_only_and_diagnostics.py
+++ b/tests/test_sensor_electricity_only_and_diagnostics.py
@@ -8,7 +8,6 @@ import pytest
 from custom_components.red_energy.const import DOMAIN, SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS
 from custom_components.red_energy.sensor import (
     RedEnergyAddressSensor,
-    RedEnergyMaxDemandTimeSensor,
     RedEnergyPaymentTypeSensor,
     RedEnergyProductNameSensor,
     RedEnergySolarSensor,
@@ -128,34 +127,6 @@ async def test_electricity_only_sensors_created_for_electricity_account():
     await async_setup_entry(hass, config_entry, async_add_entities)
 
     assert any(isinstance(e, RedEnergySolarSensor) for e in added_entities)
-
-
-@pytest.mark.asyncio
-async def test_max_demand_time_disabled_by_default():
-    """The Max Demand Interval Start sensor must default to disabled."""
-    coordinator = _coordinator(ELECTRICITY_SERVICE_METADATA, SERVICE_TYPE_ELECTRICITY)
-    config_entry = MagicMock()
-    config_entry.entry_id = "entry1"
-    config_entry.options = {"enable_advanced_sensors": True}
-
-    hass = MagicMock()
-    hass.data = {
-        DOMAIN: {
-            "entry1": {
-                "coordinator": coordinator,
-                "selected_accounts": ["2000002"],
-                "services": [SERVICE_TYPE_ELECTRICITY],
-            }
-        }
-    }
-
-    added_entities = []
-    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
-
-    await async_setup_entry(hass, config_entry, async_add_entities)
-
-    max_demand_time = next(e for e in added_entities if isinstance(e, RedEnergyMaxDemandTimeSensor))
-    assert max_demand_time._attr_entity_registry_enabled_default is False
 
 
 def test_address_sensor_formats_full_address():


### PR DESCRIPTION
## Summary
- Renames the "Balance" sensor to "Account Balance" - `unique_id` unchanged for backward compatibility
- Removes the "Max Demand Interval Start" sensor entirely: it was already disabled by default (rarely useful on its own, and Red Energy frequently omits the demand-interval timestamp even when max_demand_kw is present, so it commonly showed unknown). Since it defaulted to disabled, most users never had it enabled; anyone who did will see it become unavailable and can remove it from the entity registry
- Updates README and CLAUDE.md sensor counts/listings to match