### PR TITLE
fix: remove hardcoded sw_version, timing race in usage window

### DIFF
--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -72,7 +72,7 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
         )
 
-    def _get_billing_period_start(self, service: dict[str, Any]) -> datetime:
+    def _get_billing_period_start(self, service: dict[str, Any], end_date: datetime | None = None) -> datetime:
         """Resolve the current billing period's start date.
 
         lastBillDate is the final day of the *previous* billing period, so
@@ -80,8 +80,15 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         day's usage/cost is double-counted across both periods. Falls back
         to a 30-day window when lastBillDate is missing, invalid, in the
         future, or implausibly old (>90 days).
+
+        end_date defaults to now, but callers that already have their own
+        "now" snapshot (e.g. _get_usage_period_dates) should pass it in -
+        otherwise a second, independently-sampled datetime.now() here can
+        land fractionally later than the caller's, making the two disagree
+        by a few microseconds on where exactly 30 days back falls.
         """
-        end_date = datetime.now()
+        if end_date is None:
+            end_date = datetime.now()
         start_date = None
 
         last_bill_date = service.get("lastBillDate")
@@ -127,7 +134,7 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         handling of a missing lastBillDate.
         """
         end_date = datetime.now()
-        start_date = self._get_billing_period_start(service)
+        start_date = self._get_billing_period_start(service, end_date=end_date)
 
         next_bill_date_str = service.get("nextBillDate")
         if next_bill_date_str:

--- a/custom_components/red_energy/device_manager.py
+++ b/custom_components/red_energy/device_manager.py
@@ -77,7 +77,11 @@ class RedEnergyDeviceManager:
             "name": device_name,
             "manufacturer": MANUFACTURER,
             "model": self._get_device_model(account_services),
-            "sw_version": self._get_software_version(),
+            # Explicitly None (not omitted) to clear the stale hardcoded
+            # "1.4.0" placeholder on existing devices - async_get_or_create
+            # treats an omitted field as UNDEFINED (leave unchanged), not
+            # None (clear it).
+            "sw_version": None,
             "configuration_url": "https://www.redenergy.com.au/login",
         }
         
@@ -121,11 +125,6 @@ class RedEnergyDeviceManager:
             return "Gas Monitor"
         else:
             return "Energy Monitor"
-
-    def _get_software_version(self) -> str:
-        """Get the integration software version."""
-        # This could be enhanced to read from manifest.json
-        return "1.4.0"
 
     async def _update_device_attributes(
         self, 

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.19.3"
+  "version": "1.19.4"
 }

--- a/tests/test_device_manager_split_accounts.py
+++ b/tests/test_device_manager_split_accounts.py
@@ -83,6 +83,25 @@ async def test_device_model_reflects_accounts_own_service_not_global_toggle():
 
 
 @pytest.mark.asyncio
+async def test_sw_version_explicitly_cleared_not_omitted():
+    """sw_version must be explicitly None, not just absent from kwargs -
+    async_get_or_create treats an omitted field as "leave unchanged", which
+    would leave a stale hardcoded value on devices created by older
+    versions of the integration."""
+    manager = _make_device_manager()
+
+    await manager._create_property_device(
+        "2000002",
+        _property_info("1 Example Street, Testville", SERVICE_TYPE_ELECTRICITY),
+        [SERVICE_TYPE_ELECTRICITY],
+    )
+
+    _, kwargs = manager._device_registry.async_get_or_create.call_args
+    assert "sw_version" in kwargs
+    assert kwargs["sw_version"] is None
+
+
+@pytest.mark.asyncio
 async def test_device_name_shows_address_service_and_account_number():
     """Device name must read '{address} - {service} ({accountNumber})', using
     extraShortForm for the address rather than the internal composite ID."""

--- a/tests/test_stage5_enhancements.py
+++ b/tests/test_stage5_enhancements.py
@@ -339,7 +339,6 @@ def test_device_management_features():
     
     # Check for device model generation
     assert "_get_device_model" in content
-    assert "_get_software_version" in content
     
     # Check for diagnostics support
     assert "async_get_device_diagnostics" in content


### PR DESCRIPTION
## Summary
- Removes the device registry's `sw_version` field, which was hardcoded to a stale `"1.4.0"` regardless of the integration's actual version. Per HA's device registry convention, `sw_version` identifies a physical device's own firmware - there's no such firmware here (Red Energy is a cloud billing/usage API), so the field never had a meaningful value to hold
- Explicitly clears it to `None` (not just omitted) so existing devices created by earlier versions also lose the stale value - `async_get_or_create` treats an omitted field as "leave unchanged"
- Also fixes an unrelated, pre-existing timing bug found while testing: `_get_usage_period_dates` and `_get_billing_period_start` each independently called `datetime.now()`, so the 30-day fallback window could truncate to 29 days when the two calls landed a few microseconds apart. `_get_billing_period_start` now accepts the caller's `end_date` so both share the same instant