### PR TITLE
fix: align README polling interval wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A comprehensive Home Assistant custom integration for Red Energy (Australian ene
 
 ### 🔧 **Configuration & Management**
 - **UI-First Setup**: Complete configuration through Home Assistant UI
-- **Flexible Polling**: Configurable update intervals (15min to 4hours)
+- **Flexible Polling**: Configurable update intervals (15min, 30min (default), 1hour, 2hours, 4hours)
 - **Service Calls**: Manual refresh, credential updates, and data export
 - **Energy Dashboard Integration**: Native Home Assistant Energy dashboard support
 

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.19.4"
+  "version": "1.19.5"
 }


### PR DESCRIPTION
- README's polling interval description said "15min to 4hours" while info.md already listed the discrete options with default
- Updated README to match info.md's wording: "15min, 30min (default), 1hour, 2hours, 4hours"