### PR TITLE
fix: Current Period last_reset off by one day

### DIFF
--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.19.5"
+  "version": "1.19.6"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -1,7 +1,7 @@
 """Red Energy sensor platform."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -324,7 +324,12 @@ class RedEnergyBaseSensor(CoordinatorEntity, SensorEntity):
         return f"{period_days} days (since last bill)"
 
     def _get_last_bill_reset(self) -> datetime | None:
-        """Return the last bill date as a UTC datetime for last_reset."""
+        """Return the current billing period start as a UTC datetime for last_reset.
+
+        lastBillDate is the last day of the *previous* billing period, not
+        the first day of the current one - matches _get_billing_period_start
+        in coordinator.py.
+        """
         metadata = self.coordinator.get_service_metadata(self._property_id, self._service_type)
         if not metadata:
             return None
@@ -332,7 +337,8 @@ class RedEnergyBaseSensor(CoordinatorEntity, SensorEntity):
         if not last_bill:
             return None
         try:
-            return dt_util.as_utc(datetime.strptime(last_bill, "%Y-%m-%d"))
+            billing_period_start = datetime.strptime(last_bill, "%Y-%m-%d") + timedelta(days=1)
+            return dt_util.as_utc(billing_period_start)
         except (ValueError, TypeError):
             return None
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -392,6 +392,16 @@ class TestImportExportSensors:
         assert sensor.state_class == SensorStateClass.TOTAL
         assert sensor._attr_name == "Current Period Import Usage"
 
+    def test_total_import_usage_sensor_last_reset_is_day_after_last_bill_date(self):
+        """Issue #87: lastBillDate is the previous period's last day, so
+        last_reset must be lastBillDate + 1 day to match billing_period_start."""
+        coordinator = create_mock_coordinator()
+        config_entry = create_mock_config_entry()
+
+        sensor = RedEnergyTotalImportUsageSensor(coordinator, config_entry, "prop-001", SERVICE_TYPE_ELECTRICITY)
+
+        assert sensor.last_reset.date().isoformat() == "2024-01-02"
+
     def test_total_export_usage_sensor(self):
         """Test current period export usage sensor."""
         coordinator = create_mock_coordinator()

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -289,7 +289,7 @@ class TestBillingPeriodServiceChargeSensor:
         assert sensor.native_value is None
         assert sensor.extra_state_attributes is None
 
-    def test_last_reset_matches_last_bill_date(self, coordinator):
+    def test_last_reset_matches_billing_period_start(self, coordinator):
         _set_coordinator_data(
             coordinator,
             [SUPPLY_CHARGE_RATE],
@@ -299,10 +299,10 @@ class TestBillingPeriodServiceChargeSensor:
         sensor = RedEnergyBillingPeriodServiceChargeSensor(
             coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
         )
-        # last_reset must match the sibling billing-period TOTAL sensors
-        # (_get_last_bill_reset -> raw lastBillDate), not the +1-day
-        # billing_period_start used for the day-count/attribute math.
-        assert sensor.last_reset.date().isoformat() == "2025-07-25"
+        # last_reset must match billing_period_start (lastBillDate + 1 day),
+        # since lastBillDate is the last day of the *previous* period, not
+        # the first day of the current one.
+        assert sensor.last_reset.date().isoformat() == "2025-07-26"
 
     def test_last_reset_is_none_when_last_bill_date_missing(self, coordinator):
         _set_coordinator_data(


### PR DESCRIPTION
Fixes #87

- `_get_last_bill_reset()` in sensor.py used `lastBillDate` directly for `last_reset`, but `lastBillDate` is the last day of the *previous* billing period, not the first day of the current one
- `coordinator.py`'s `_get_billing_period_start()` already applies `lastBillDate + 1 day` for this reason (issue #63), but the fix was never propagated to the sibling `last_reset` calc in sensor.py
- Fixed `_get_last_bill_reset()` to use the same `+ 1 day` offset, aligning `last_reset` with `billing_period_start`/`from_date` shown in sensor attributes

Affects all 10 sensor classes sharing this helper: Current Period Import/Export Usage, Current Period Import Cost/Export Credit, Current Period Service Charge, and the CL2/TOU-derived sensors (Cl2Energy, Cl2Cost, CorrectedPeak/Shoulder/OffpeakImport). Daily sensors are unaffected - they use a separate `_get_latest_usage_date_reset()` keyed off `usageDate`, not `lastBillDate`.