### PR TITLE
fix: include demand charge in Projected Charges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,8 @@ The `/usage/interval` endpoint returns an **array of daily summaries**, each wit
 
 Two tiers of sensors per service (electricity or gas) per property:
 
-- **Core sensors** (23 per service, always created): daily/total import/export usage and cost, account metadata, billing dates, plan name
-- **Advanced sensors** (13 for electricity, 3 for gas, optional toggle): time-of-use breakdown (peak/offpeak/shoulder), peak demand, carbon emissions, demand charge (Demand-tariff plans)
+- **Core sensors** (25 for electricity, 20 for gas, always created): daily/total import/export usage and cost, account metadata, billing dates, plan name
+- **Advanced sensors** (16 for electricity, 6 for gas, optional toggle): time-of-use breakdown (peak/offpeak/shoulder), peak demand, carbon emissions, service/demand charge accrual, projected net cost/charges
 
 Unique IDs follow the pattern: `{domain}_{entry_id}_{property_id}_{service_type}_{sensor_type}`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ The `/usage/interval` endpoint returns an **array of daily summaries**, each wit
 Two tiers of sensors per service (electricity or gas) per property:
 
 - **Core sensors** (23 per service, always created): daily/total import/export usage and cost, account metadata, billing dates, plan name
-- **Advanced sensors** (12 for electricity, 3 for gas, optional toggle): time-of-use breakdown (peak/offpeak/shoulder), peak demand, carbon emissions
+- **Advanced sensors** (13 for electricity, 3 for gas, optional toggle): time-of-use breakdown (peak/offpeak/shoulder), peak demand, carbon emissions, demand charge (Demand-tariff plans)
 
 Unique IDs follow the pattern: `{domain}_{entry_id}_{property_id}_{service_type}_{sensor_type}`
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Since electricity-only concepts (solar, export, time-of-use tariffs, demand, car
 One diagnostic sensor per rate on the account's actual plan (e.g. Peak, Off-Peak, Shoulder, Supply, Demand, or tiered gas usage steps), named `Rate {rate description}`. The state is the rate in dollars including GST; unit, excl-GST rate, and step description are exposed as attributes. The number of these sensors depends entirely on the plan's tariff structure.
 
 ### Advanced Sensors (Optional)
-Enabled via the "Advanced Sensors" integration option. **12 sensors for electricity accounts, 3 for gas accounts** (gas accounts only get Daily/Monthly Average and Peak Usage, which apply to total usage regardless of service):
+Enabled via the "Advanced Sensors" integration option. **13 sensors for electricity accounts, 3 for gas accounts** (gas accounts only get Daily/Monthly Average and Peak Usage, which apply to total usage regardless of service):
 
 **Statistical Analysis:**
 - Daily Average - Average daily usage
@@ -130,7 +130,7 @@ Enabled via the "Advanced Sensors" integration option. **12 sensors for electric
 - Peak Usage - Highest single-day usage with date
 - Efficiency *(electricity only)* - Usage consistency efficiency rating (0-100%)
 - Projected Net Cost - Estimated net energy cost (import minus export credit) for the full billing cycle, extrapolated from usage to date. GST-inclusive; not Red Energy's own figure
-- Projected Charges - Projected Net Cost plus the daily service/supply charge projected across the full cycle, for a fuller bill estimate. GST-inclusive; not Red Energy's own figure
+- Projected Charges - Projected Net Cost plus the daily service/supply charge projected across the full cycle, for a fuller bill estimate; for Demand-tariff plans this also includes the projected demand charge. GST-inclusive; not Red Energy's own figure
 
 **Time-of-Use Breakdown** *(electricity only - gas has no ToU tariff)*:
 - Peak/Offpeak/Shoulder Import Usage
@@ -138,6 +138,7 @@ Enabled via the "Advanced Sensors" integration option. **12 sensors for electric
 
 **Demand & Environmental** *(electricity only)*:
 - Max Demand - Maximum demand (kW)
+- Current Period Demand Charge - Accumulated demand charge from the start of the current billing period to the latest completed usage day, for Demand-tariff plans. GST-inclusive; not Red Energy's own figure
 - Carbon Emission Tonne - Carbon emissions (tonnes CO₂e)
 
 ### Diagnostics Button

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Red Energy bills electricity and gas as **separate accounts**, even at the same 
 Since electricity-only concepts (solar, export, time-of-use tariffs, demand, carbon emissions) don't apply to gas, those sensors are only created on electricity accounts - a gas-only account won't get a permanently meaningless "Solar" entity, for example.
 
 ### Core Sensors (Always Available)
-**24 sensors for electricity accounts, 19 for gas accounts** (gas accounts skip the 5 electricity-only ones marked below):
+**25 sensors for electricity accounts, 20 for gas accounts** (gas accounts skip the 5 electricity-only ones marked below):
 
 **Usage & Cost Tracking:**
 - Daily Import Usage - Daily imported energy (kWh/MJ)
@@ -122,13 +122,14 @@ Since electricity-only concepts (solar, export, time-of-use tariffs, demand, car
 One diagnostic sensor per rate on the account's actual plan (e.g. Peak, Off-Peak, Shoulder, Supply, Demand, or tiered gas usage steps), named `Rate {rate description}`. The state is the rate in dollars including GST; unit, excl-GST rate, and step description are exposed as attributes. The number of these sensors depends entirely on the plan's tariff structure.
 
 ### Advanced Sensors (Optional)
-Enabled via the "Advanced Sensors" integration option. **13 sensors for electricity accounts, 3 for gas accounts** (gas accounts only get Daily/Monthly Average and Peak Usage, which apply to total usage regardless of service):
+Enabled via the "Advanced Sensors" integration option. **16 sensors for electricity accounts, 6 for gas accounts** (gas accounts get Daily/Monthly Average, Peak Usage, Current Period Service Charge, Projected Net Cost, and Projected Charges - the rest are electricity-only, marked below):
 
 **Statistical Analysis:**
 - Daily Average - Average daily usage
 - Monthly Average - Projected monthly usage (billing period-adjusted)
 - Peak Usage - Highest single-day usage with date
 - Efficiency *(electricity only)* - Usage consistency efficiency rating (0-100%)
+- Current Period Service Charge - Accumulated daily service/supply charge from the start of the current billing period to the latest completed usage day (AUD)
 - Projected Net Cost - Estimated net energy cost (import minus export credit) for the full billing cycle, extrapolated from usage to date. GST-inclusive; not Red Energy's own figure
 - Projected Charges - Projected Net Cost plus the daily service/supply charge projected across the full cycle, for a fuller bill estimate; for Demand-tariff plans this also includes the projected demand charge. GST-inclusive; not Red Energy's own figure
 

--- a/custom_components/red_energy/const.py
+++ b/custom_components/red_energy/const.py
@@ -100,6 +100,7 @@ SENSOR_TYPE_ADDRESS: Final = "address"
 SENSOR_TYPE_PAYMENT_TYPE: Final = "payment_type"
 SENSOR_TYPE_RATE_PREFIX: Final = "rate"
 SENSOR_TYPE_BILLING_PERIOD_SERVICE_CHARGE: Final = "billing_period_service_charge"
+SENSOR_TYPE_CURRENT_PERIOD_DEMAND_CHARGE: Final = "current_period_demand_charge"
 
 # Configuration options
 CONF_SCAN_INTERVAL: Final = "scan_interval"

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -767,6 +767,57 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
         represented_day_count = (billing_period_end - billing_period_start).days + 1
         return rate["rate_incl_gst_dollars"] * represented_day_count
 
+    def get_billing_period_demand_charge(self, property_id: str, service_type: str) -> dict[str, Any] | None:
+        """Get the accumulated demand charge from the billing period start
+        through the latest completed usageDate, inclusive.
+
+        Returns None when the plan isn't a Demand plan (see
+        _is_demand_plan), when there's no resolvable seasonal demand rate
+        for today (see _get_demand_rate), or when max demand data is
+        unavailable for the period. The demand charge is
+        max_demand_kw * demand_rate_incl_gst, accrued per represented day
+        - mirroring get_billing_period_service_charge's day-count
+        convention (latest completed usageDate as period end, not
+        datetime.now(), so an unconfirmed day is never counted).
+        """
+        if not self._is_demand_plan(property_id, service_type):
+            return None
+
+        demand_rate = self._get_demand_rate(property_id, service_type)
+        if demand_rate is None:
+            return None
+
+        max_demand_data = self.get_max_demand_data(property_id, service_type)
+        if max_demand_data is None:
+            return None
+        max_demand_kw = max_demand_data["max_demand_kw"]
+
+        latest_usage_date_str = self.get_latest_usage_date(property_id, service_type)
+        if not latest_usage_date_str:
+            return None
+
+        try:
+            billing_period_end = datetime.strptime(latest_usage_date_str, "%Y-%m-%d").date()
+        except (ValueError, TypeError):
+            return None
+
+        service_metadata = self.get_service_metadata(property_id, service_type) or {}
+        billing_period_start = self._get_billing_period_start(service_metadata).date()
+
+        if billing_period_end < billing_period_start:
+            return None
+
+        represented_day_count = (billing_period_end - billing_period_start).days + 1
+        demand_rate_incl_gst = demand_rate["rate_incl_gst_dollars"]
+
+        return {
+            "demand_charge": max_demand_kw * demand_rate_incl_gst * represented_day_count,
+            "max_demand_kw": max_demand_kw,
+            "demand_rate_incl_gst": demand_rate_incl_gst,
+            "demand_rate_desc": demand_rate["rate_desc"],
+            "represented_day_count": represented_day_count,
+        }
+
     def get_projected_charges(self, property_id: str, service_type: str) -> dict[str, Any] | None:
         """Estimate the current billing cycle's total charge, GST-inclusive.
 
@@ -851,13 +902,34 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
 
             estimated_charges = projected_net_cost + (service_charge_rate * days_in_cycle)
 
-        Both terms are GST-inclusive (get_projected_charges computes its
+        For Demand-tariff plans (see _is_demand_plan), a third term is
+        added - the projected demand charge, using the account's current
+        max observed demand extrapolated across the full billing cycle
+        at the seasonally-resolved demand rate (see _get_demand_rate):
+
+            + (max_demand_kw * demand_rate_incl_gst * days_in_cycle)
+
+        This mirrors Red Energy's own bill structure (see
+        redenergy.com.au/energy-billing/demand-tariffs.html): usage +
+        supply charges + a demand charge based on highest 30-minute demand
+        in the billing period. Extrapolating today's max observed demand
+        across the remaining cycle is an approximation - actual demand
+        could still increase before the cycle ends - but it's the same
+        linear-extrapolation approach already used for the energy-cost
+        projection, and is far closer to Red Energy's own figure than
+        omitting the term entirely (previously a ~$35 undercount on a
+        live account).
+
+        All terms are GST-inclusive (get_projected_charges computes its
         own GST-inclusive net_cost_to_date; rate_incl_gst_dollars already
         is), so no further GST adjustment is needed here.
 
         Returns None when there's no daily service-charge rate (some plans
         don't have one) or when the underlying net-cost projection itself
-        is unavailable.
+        is unavailable. The demand-charge term is additive and optional -
+        its absence (non-Demand plan, or no resolvable demand rate/max
+        demand data) never causes this method to return None; the result
+        simply omits "estimated_demand_charge"/"demand_rate_incl_gst".
         """
         rate = self._find_service_charge_rate(property_id, service_type)
         if rate is None:
@@ -869,13 +941,28 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
 
         estimated_service_charge = rate["rate_incl_gst_dollars"] * projection["days_in_cycle"]
 
-        return {
+        result = {
             "estimated_charges": projection["projected_charges"] + estimated_service_charge,
             "estimated_net_cost": projection["projected_charges"],
             "estimated_service_charge": estimated_service_charge,
             "days_in_cycle": projection["days_in_cycle"],
             "service_rate_incl_gst": rate["rate_incl_gst_dollars"],
         }
+
+        if self._is_demand_plan(property_id, service_type):
+            demand_rate = self._get_demand_rate(property_id, service_type)
+            max_demand_data = self.get_max_demand_data(property_id, service_type)
+            if demand_rate is not None and max_demand_data is not None:
+                estimated_demand_charge = (
+                    max_demand_data["max_demand_kw"]
+                    * demand_rate["rate_incl_gst_dollars"]
+                    * projection["days_in_cycle"]
+                )
+                result["estimated_charges"] += estimated_demand_charge
+                result["estimated_demand_charge"] = estimated_demand_charge
+                result["demand_rate_incl_gst"] = demand_rate["rate_incl_gst_dollars"]
+
+        return result
 
     def get_cl2_inference(self, property_id: str, service_type: str) -> dict[str, Any] | None:
         """Aggregate CL2/TOU inference across a service's usage period.

--- a/custom_components/red_energy/coordinator.py
+++ b/custom_components/red_energy/coordinator.py
@@ -668,6 +668,75 @@ class RedEnergyDataCoordinator(DataUpdateCoordinator):
             None,
         )
 
+    def _is_demand_plan(self, property_id: str, service_type: str) -> bool:
+        """Return whether the service's plan is a Demand-tariff plan.
+
+        Detected via planName containing "demand" case-insensitively - Red
+        Energy's own site draws this exact distinction ("Demand Tariffs"
+        vs. "Residential Time of Use tariff"). A missing/None planName
+        returns False, never True - unknown must never be treated as
+        "yes, bill a demand charge."
+        """
+        metadata = self.get_service_metadata(property_id, service_type) or {}
+        plan_name = metadata.get("planName")
+        if not isinstance(plan_name, str):
+            return False
+        return "demand" in plan_name.lower()
+
+    # Season windows for demand-rate selection, hardcoded per Red Energy's
+    # published seasonal demand tariff structure (not derivable from any
+    # API field - the API returns all seasonal rates simultaneously with
+    # no "current season" indicator).
+    #   Summer: 1 Nov - 31 Mar (wraps the year boundary)
+    #   Non-Summer: 1 Jun - 31 Aug
+    #   Temperate: 1 Apr - 31 May, and 1 Sep - 31 Oct
+    _DEMAND_SEASON_LABELS: dict[str, frozenset[str]] = {
+        "SUMMER": frozenset({"demand summer"}),
+        "NON_SUMMER": frozenset({"demand non summer"}),
+        "TEMPERATE": frozenset({"demand temperate peak", "demand temperate"}),
+    }
+
+    @staticmethod
+    def _demand_season_for_date(on_date: date) -> str:
+        """Return which seasonal demand season label applies to on_date."""
+        month = on_date.month
+        if month in (11, 12, 1, 2, 3):
+            return "SUMMER"
+        if month in (6, 7, 8):
+            return "NON_SUMMER"
+        # Remaining months: 4, 5, 9, 10 are all TEMPERATE in full
+        return "TEMPERATE"
+
+    def _get_demand_rate(
+        self, property_id: str, service_type: str, on_date: date | None = None
+    ) -> dict[str, Any] | None:
+        """Find the seasonal demand-charge rate applicable on on_date.
+
+        Matches by normalized rate_desc against the season's label set
+        (see _DEMAND_SEASON_LABELS), mirroring cl2_inference.resolve_rate_roles's
+        matching style. Returns None - never guesses - when zero or more
+        than one rate matches the resolved season's label set.
+        """
+        if on_date is None:
+            on_date = datetime.now().date()
+
+        season = self._demand_season_for_date(on_date)
+        labels = self._DEMAND_SEASON_LABELS[season]
+
+        rates = self.get_service_rates(property_id, service_type)
+        matches = []
+        for rate in rates:
+            rate_desc = rate.get("rate_desc")
+            if not isinstance(rate_desc, str):
+                continue
+            normalized = " ".join(rate_desc.strip().lower().split())
+            if normalized in labels:
+                matches.append(rate)
+
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
     def get_billing_period_service_charge(self, property_id: str, service_type: str) -> float | None:
         """Get the accumulated service charge from the billing period start
         through the latest completed usageDate, inclusive.

--- a/custom_components/red_energy/manifest.json
+++ b/custom_components/red_energy/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/craibo/ha-red-energy-au/issues",
   "requirements": ["aiohttp", "voluptuous"],
-  "version": "1.20.0"
+  "version": "1.21.0"
 }

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -1118,10 +1118,12 @@ class RedEnergyProjectedChargesSensor(RedEnergyBaseSensor):
 
     Projected net energy cost (see RedEnergyProjectedNetCostSensor) plus
     the daily service/supply charge projected across the full billing
-    cycle, giving a fuller bill estimate. Unavailable when the plan has no
-    daily service-charge rate, or when the underlying net-cost projection
-    itself is unavailable (see coordinator.get_estimated_current_period_charges).
-    Both components are GST-inclusive.
+    cycle, giving a fuller bill estimate. For Demand-tariff plans with a
+    resolvable seasonal demand rate, the projected demand charge is added
+    as a third term (see coordinator.get_estimated_current_period_charges).
+    Unavailable when the plan has no daily service-charge rate, or when the
+    underlying net-cost projection itself is unavailable. All components
+    are GST-inclusive.
     """
 
     def __init__(
@@ -1152,7 +1154,7 @@ class RedEnergyProjectedChargesSensor(RedEnergyBaseSensor):
         if result is None:
             return None
 
-        return {
+        attributes = {
             "estimated_net_cost": round(result["estimated_net_cost"], 2),
             "estimated_service_charge": round(result["estimated_service_charge"], 2),
             "days_in_cycle": result["days_in_cycle"],
@@ -1160,6 +1162,12 @@ class RedEnergyProjectedChargesSensor(RedEnergyBaseSensor):
             "estimation_method": "linear",
             "gst_basis": "inclusive",
         }
+
+        if "estimated_demand_charge" in result:
+            attributes["estimated_demand_charge"] = round(result["estimated_demand_charge"], 2)
+            attributes["demand_rate_incl_gst"] = result["demand_rate_incl_gst"]
+
+        return attributes
 
 
 class RedEnergyAddressSensor(RedEnergyBaseSensor):

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -1028,10 +1028,6 @@ class RedEnergyCurrentPeriodDemandChargeSensor(RedEnergyBaseSensor):
         self._attr_state_class = SensorStateClass.TOTAL
         self._attr_icon = "mdi:transmission-tower-import"
 
-    def _billing_period_start_date(self) -> datetime | None:
-        service_metadata = self.coordinator.get_service_metadata(self._property_id, self._service_type) or {}
-        return self.coordinator._get_billing_period_start(service_metadata)
-
     @property
     def last_reset(self) -> datetime | None:
         """Return the billing period start date so HA statistics reset correctly."""

--- a/custom_components/red_energy/sensor.py
+++ b/custom_components/red_energy/sensor.py
@@ -39,6 +39,7 @@ from .const import (
     SENSOR_TYPE_CURRENT_PERIOD_IMPORT_COST,
     SENSOR_TYPE_CURRENT_PERIOD_IMPORT_USAGE,
     SENSOR_TYPE_CURRENT_PERIOD_NET_COST,
+    SENSOR_TYPE_CURRENT_PERIOD_DEMAND_CHARGE,
     SENSOR_TYPE_DAILY_AVERAGE,
     SENSOR_TYPE_DISTRIBUTOR,
     SENSOR_TYPE_EFFICIENCY,
@@ -170,6 +171,8 @@ async def async_setup_entry(
                     RedEnergyCarbonEmissionSensor(coordinator, config_entry, account_id, service_type),
                     # NEW: Service/supply charge sensor
                     RedEnergyBillingPeriodServiceChargeSensor(coordinator, config_entry, account_id, service_type),
+                    # NEW: Demand charge sensor (Demand-tariff plans only)
+                    RedEnergyCurrentPeriodDemandChargeSensor(coordinator, config_entry, account_id, service_type),
                     # NEW: Projected net cost (energy only, issues #75, #77)
                     RedEnergyProjectedNetCostSensor(coordinator, config_entry, account_id, service_type),
                     # NEW: Projected charges (net cost + service charge, issue #77)
@@ -990,6 +993,68 @@ class RedEnergyBillingPeriodServiceChargeSensor(RedEnergyBaseSensor):
             "service_rate_incl_gst": rate_incl_gst,
             "service_rate_excl_gst": rate_excl_gst,
             "calculation": f"service_rate_incl_gst × {represented_day_count} days",
+        }
+
+
+class RedEnergyCurrentPeriodDemandChargeSensor(RedEnergyBaseSensor):
+    """Red Energy current period demand charge sensor.
+
+    Represents the accumulated demand charge from the start of the
+    current billing period through the latest completed usageDate,
+    inclusive, for Demand-tariff electricity plans (see
+    coordinator._is_demand_plan). Unavailable for non-Demand plans, when
+    no seasonal demand rate resolves for today, or when max demand data
+    is unavailable. Gas services never have demand charges
+    (_electricity_only), matching RedEnergyMaxDemandSensor's gating.
+    """
+
+    _electricity_only = True
+
+    def __init__(
+        self,
+        coordinator: RedEnergyDataCoordinator,
+        config_entry: ConfigEntry,
+        property_id: str,
+        service_type: str,
+    ) -> None:
+        """Initialize the current period demand charge sensor."""
+        super().__init__(
+            coordinator, config_entry, property_id, service_type, SENSOR_TYPE_CURRENT_PERIOD_DEMAND_CHARGE
+        )
+        self._attr_name = "Current Period Demand Charge"
+
+        self._attr_device_class = SensorDeviceClass.MONETARY
+        self._attr_native_unit_of_measurement = "AUD"
+        self._attr_state_class = SensorStateClass.TOTAL
+        self._attr_icon = "mdi:transmission-tower-import"
+
+    def _billing_period_start_date(self) -> datetime | None:
+        service_metadata = self.coordinator.get_service_metadata(self._property_id, self._service_type) or {}
+        return self.coordinator._get_billing_period_start(service_metadata)
+
+    @property
+    def last_reset(self) -> datetime | None:
+        """Return the billing period start date so HA statistics reset correctly."""
+        return self._get_last_bill_reset()
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the accumulated billing period demand charge, GST-inclusive."""
+        result = self.coordinator.get_billing_period_demand_charge(self._property_id, self._service_type)
+        return round(result["demand_charge"], 2) if result is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return the max demand, rate basis, and day count for the demand charge."""
+        result = self.coordinator.get_billing_period_demand_charge(self._property_id, self._service_type)
+        if result is None:
+            return None
+
+        return {
+            "max_demand_kw": result["max_demand_kw"],
+            "demand_rate_incl_gst": result["demand_rate_incl_gst"],
+            "demand_rate_desc": result["demand_rate_desc"],
+            "represented_day_count": result["represented_day_count"],
         }
 
 

--- a/info.md
+++ b/info.md
@@ -27,7 +27,7 @@ A comprehensive Home Assistant custom integration for Red Energy (Australian ene
 
 ### Core Sensors (Per Account/Device)
 - Daily and total usage/cost tracking (kWh for electricity, MJ for gas) since last bill
-- Account metadata: NMI, meter type, energy plan, distributor, payment type, address (with lat/long for mapping), balance, arrears, bill dates
+- Account metadata: NMI, meter type, product name, plan name, distributor, payment type, address (with lat/long for mapping), balance, arrears, bill dates
 - Electricity-only concepts (solar, export usage/credit) are only created on electricity accounts, never on gas
 
 ### Advanced Analytics (Optional)
@@ -35,6 +35,8 @@ A comprehensive Home Assistant custom integration for Red Energy (Australian ene
 - Peak usage detection with date attribution  
 - Efficiency ratings (0-100%) based on usage consistency - electricity only
 - Time-of-use breakdown, max demand, and carbon emissions - electricity only
+- Projected net cost and projected charges (including demand charge for Demand-tariff plans) for the current billing cycle
+- Accrued service charge and demand charge (Demand-tariff plans) since the start of the current billing period
 
 ### Billing Period Alignment
 - Automatic alignment with Red Energy billing cycles

--- a/tests/test_projected_charges.py
+++ b/tests/test_projected_charges.py
@@ -528,6 +528,57 @@ class TestProjectedChargesSensor:
         assert sensor.native_value is None
         assert sensor.extra_state_attributes is None
 
+    def test_attributes_include_demand_charge_for_demand_plan(self, coordinator):
+        """On a Demand plan with a resolvable seasonal rate and max demand
+        data, the projected demand charge and its rate are surfaced as
+        extra_state_attributes alongside the existing keys."""
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2026-01-18", 35.0, max_demand_kw=4.608)],
+            last_bill_date="2026-01-01",
+            next_bill_date="2026-01-31",
+            rates=[SUPPLY_CHARGE_RATE, DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            plan_name="Residential Demand Solar",
+        )
+        sensor = RedEnergyProjectedChargesSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            attrs = sensor.extra_state_attributes
+
+        expected_demand_charge = 4.608 * 0.253 * 29
+        assert attrs["estimated_demand_charge"] == pytest.approx(round(expected_demand_charge, 2))
+        assert attrs["demand_rate_incl_gst"] == pytest.approx(0.253)
+        # existing keys must still be present and unaffected
+        assert attrs["days_in_cycle"] == 29
+        assert attrs["gst_basis"] == "inclusive"
+
+    def test_attributes_omit_demand_charge_for_non_demand_plan(self, coordinator):
+        """Non-Demand-plan accounts (e.g. Time of Use) must not expose the
+        demand-charge attributes at all - the keys must be absent, not
+        present with a None value."""
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2025-08-01", 35.0)],
+            last_bill_date="2025-07-25",
+            next_bill_date="2025-08-22",
+            rates=[SUPPLY_CHARGE_RATE],
+            plan_name="Residential Time of Use",
+        )
+        sensor = RedEnergyProjectedChargesSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+
+        attrs = sensor.extra_state_attributes
+        assert "estimated_demand_charge" not in attrs
+        assert "demand_rate_incl_gst" not in attrs
+        # existing keys unaffected
+        assert attrs["days_in_cycle"] == 27
+        assert attrs["gst_basis"] == "inclusive"
+
 
 def _mock_coordinator_for_setup(service_type=SERVICE_TYPE_ELECTRICITY, property_id="2000002"):
     coordinator = MagicMock()

--- a/tests/test_projected_charges.py
+++ b/tests/test_projected_charges.py
@@ -87,6 +87,7 @@ def _set_coordinator_data(
     last_bill_date=None,
     next_bill_date=None,
     rates=None,
+    plan_name=None,
 ):
     """Build coordinator.data with both the property.services (metadata)
     and top-level services (usage) shapes get_service_metadata/get_service_usage
@@ -103,6 +104,8 @@ def _set_coordinator_data(
         service_metadata["lastBillDate"] = last_bill_date
     if next_bill_date is not None:
         service_metadata["nextBillDate"] = next_bill_date
+    if plan_name is not None:
+        service_metadata["planName"] = plan_name
 
     services_usage = {}
     if usage_entries is not None:
@@ -130,8 +133,48 @@ def _set_coordinator_data(
     }
 
 
-def _entry(date, import_cost, export_credit=0.0):
-    return {"date": date, "import_usage": 10.0, "import_cost": import_cost, "export_credit": export_credit}
+def _entry(date, import_cost, export_credit=0.0, max_demand_kw=None):
+    entry = {"date": date, "import_usage": 10.0, "import_cost": import_cost, "export_credit": export_credit}
+    if max_demand_kw is not None:
+        entry["max_demand_kw"] = max_demand_kw
+    return entry
+
+
+DEMAND_CHARGE_RATE = {
+    "rate_code": "80008279798FB",
+    "rate_desc": "Demand Summer",
+    "rate_incl_gst_dollars": 0.253,
+    "type": "F",
+    "rate_excl_gst_cents": 23,
+    "discounted_rate_excl_gst_in_cents": 23,
+    "discounted_rate_incl_gst_in_cents": 25.3,
+    "unit": "KW/day",
+    "unit_step_desc": None,
+}
+
+DEMAND_CHARGE_RATE_NON_SUMMER = {
+    "rate_code": "80008279798FC",
+    "rate_desc": "Demand Non Summer",
+    "rate_incl_gst_dollars": 0.253,
+    "type": "F",
+    "rate_excl_gst_cents": 23,
+    "discounted_rate_excl_gst_in_cents": 23,
+    "discounted_rate_incl_gst_in_cents": 25.3,
+    "unit": "KW/day",
+    "unit_step_desc": None,
+}
+
+DEMAND_CHARGE_RATE_TEMPERATE = {
+    "rate_code": "80008279798FD",
+    "rate_desc": "Demand Temperate Peak",
+    "rate_incl_gst_dollars": 0.154,
+    "type": "F",
+    "rate_excl_gst_cents": 14,
+    "discounted_rate_excl_gst_in_cents": 14,
+    "discounted_rate_incl_gst_in_cents": 15.4,
+    "unit": "KW/day",
+    "unit_step_desc": None,
+}
 
 
 class TestGetProjectedCharges:
@@ -300,6 +343,101 @@ class TestGetEstimatedCurrentPeriodCharges:
             rates=[SUPPLY_CHARGE_RATE],
         )
         assert coordinator.get_estimated_current_period_charges("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+    def test_includes_demand_charge_for_demand_plan(self, coordinator):
+        """On a Demand plan with a resolvable seasonal rate and max demand
+        data, a third term - the demand charge extrapolated across the
+        full cycle - is added into estimated_charges."""
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2026-01-18", 35.0, max_demand_kw=4.608)],
+            last_bill_date="2026-01-01",
+            next_bill_date="2026-01-31",
+            rates=[SUPPLY_CHARGE_RATE, DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            plan_name="Residential Demand Solar",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            result = coordinator.get_estimated_current_period_charges("2000002", SERVICE_TYPE_ELECTRICITY)
+
+        assert result is not None
+        # billing_period_start = 2026-01-02, days_in_cycle = Jan 2..Jan 31 (nextBillDate, exclusive) = 29 days
+        assert result["days_in_cycle"] == 29
+        expected_demand_charge = 4.608 * 0.253 * 29
+        assert result["estimated_demand_charge"] == pytest.approx(expected_demand_charge)
+        assert result["demand_rate_incl_gst"] == pytest.approx(0.253)
+        assert result["estimated_charges"] == pytest.approx(
+            result["estimated_net_cost"] + result["estimated_service_charge"] + result["estimated_demand_charge"]
+        )
+
+    def test_omits_demand_charge_for_non_demand_plan(self, coordinator):
+        """Non-Demand-plan accounts (e.g. Time of Use) must be byte-for-byte
+        unaffected - no estimated_demand_charge/demand_rate_incl_gst keys,
+        and estimated_charges unchanged from the pre-Task-2 calculation."""
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2025-08-01", 35.0)],
+            last_bill_date="2025-07-25",
+            next_bill_date="2025-08-22",
+            rates=[SUPPLY_CHARGE_RATE],
+            plan_name="Residential Time of Use",
+        )
+        result = coordinator.get_estimated_current_period_charges("2000002", SERVICE_TYPE_ELECTRICITY)
+
+        net_cost_to_date = 35.0 * GST_MULTIPLIER
+        expected_net_projection = net_cost_to_date / 7 * 27
+        expected_service_charge = SUPPLY_CHARGE_RATE["rate_incl_gst_dollars"] * 27
+
+        assert result is not None
+        assert "estimated_demand_charge" not in result
+        assert "demand_rate_incl_gst" not in result
+        assert result["estimated_charges"] == pytest.approx(expected_net_projection + expected_service_charge)
+
+    def test_omits_demand_charge_when_no_resolvable_demand_rate(self, coordinator):
+        """Demand plan, but the demand rates present don't unambiguously
+        resolve for the current season - the demand-charge term must be
+        omitted entirely, not guessed, and estimated_charges must not
+        return None because of it."""
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2026-01-18", 35.0, max_demand_kw=4.608)],
+            last_bill_date="2026-01-01",
+            next_bill_date="2026-01-31",
+            # Only a Non-Summer demand rate is present; on_date resolves to
+            # Summer, so _get_demand_rate returns None (zero matches).
+            rates=[SUPPLY_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER],
+            plan_name="Residential Demand Solar",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            result = coordinator.get_estimated_current_period_charges("2000002", SERVICE_TYPE_ELECTRICITY)
+
+        assert result is not None
+        assert "estimated_demand_charge" not in result
+        assert "demand_rate_incl_gst" not in result
+
+    def test_omits_demand_charge_when_no_max_demand_data(self, coordinator):
+        """Demand plan with a resolvable rate but no usage entry carries
+        max_demand_kw - the demand-charge term must be omitted, not raise
+        or return None for the whole estimate."""
+        _set_coordinator_data(
+            coordinator,
+            usage_entries=[_entry("2026-01-18", 35.0)],  # no max_demand_kw
+            last_bill_date="2026-01-01",
+            next_bill_date="2026-01-31",
+            rates=[SUPPLY_CHARGE_RATE, DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            plan_name="Residential Demand Solar",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            result = coordinator.get_estimated_current_period_charges("2000002", SERVICE_TYPE_ELECTRICITY)
+
+        assert result is not None
+        assert "estimated_demand_charge" not in result
+        assert "demand_rate_incl_gst" not in result
 
 
 from homeassistant.components.sensor import SensorDeviceClass

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -382,6 +382,113 @@ class TestGetBillingPeriodServiceCharge:
         assert result == pytest.approx(1 * 1.78145)
 
 
+class TestGetBillingPeriodDemandCharge:
+    def test_computes_accrued_demand_charge(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[{"date": "2026-01-18", "import_usage": 10.0, "max_demand_kw": 4.608}],
+            last_bill_date="2026-01-01",
+            plan_name="Residential Demand Solar",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            result = coordinator.get_billing_period_demand_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+
+        assert result is not None
+        # represented_day_count = 2026-01-02 (lastBillDate + 1) .. 2026-01-18 inclusive = 17 days
+        assert result["represented_day_count"] == 17
+        assert result["max_demand_kw"] == 4.608
+        assert result["demand_rate_incl_gst"] == pytest.approx(0.253)
+        assert result["demand_rate_desc"] == "Demand Summer"
+        assert result["demand_charge"] == pytest.approx(4.608 * 0.253 * 17)
+
+    def test_none_when_not_demand_plan(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[{"date": "2026-01-18", "import_usage": 10.0, "max_demand_kw": 4.608}],
+            last_bill_date="2026-01-01",
+            plan_name="Residential Time of Use",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            result = coordinator.get_billing_period_demand_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result is None
+
+    def test_none_when_no_resolvable_demand_rate(self, coordinator):
+        """Only a Non-Summer demand rate is present; resolving for a
+        Summer date must not fall back to guessing it."""
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE_NON_SUMMER],
+            usage_entries=[{"date": "2026-01-18", "import_usage": 10.0, "max_demand_kw": 4.608}],
+            last_bill_date="2026-01-01",
+            plan_name="Residential Demand Solar",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            result = coordinator.get_billing_period_demand_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result is None
+
+    def test_none_when_no_max_demand_data(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[{"date": "2026-01-18", "import_usage": 10.0}],  # no max_demand_kw
+            last_bill_date="2026-01-01",
+            plan_name="Residential Demand Solar",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            result = coordinator.get_billing_period_demand_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result is None
+
+    def test_none_when_no_usage_data(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[],
+            last_bill_date="2026-01-01",
+            plan_name="Residential Demand Solar",
+        )
+        result = coordinator.get_billing_period_demand_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result is None
+
+    def test_none_when_latest_usage_date_before_period_start(self, coordinator):
+        """Stale/cached usage predating a just-rolled billing period must not produce a negative day count."""
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[{"date": "2025-12-20", "import_usage": 10.0, "max_demand_kw": 4.608}],
+            last_bill_date="2026-01-01",
+            plan_name="Residential Demand Solar",
+        )
+        result = coordinator.get_billing_period_demand_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result is None
+
+    def test_single_day_period_counts_as_one_day(self, coordinator):
+        """lastBillDate + 1 == latest usageDate must count as exactly 1 day, not 0."""
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[{"date": "2026-01-02", "import_usage": 10.0, "max_demand_kw": 4.608}],
+            last_bill_date="2026-01-01",
+            plan_name="Residential Demand Solar",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 2)
+            mock_dt.strptime = datetime.strptime
+            result = coordinator.get_billing_period_demand_charge("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert result is not None
+        assert result["represented_day_count"] == 1
+        assert result["demand_charge"] == pytest.approx(4.608 * 0.253 * 1)
+
+
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 
 

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -10,6 +10,7 @@ from custom_components.red_energy.coordinator import RedEnergyDataCoordinator
 from custom_components.red_energy.const import SERVICE_TYPE_ELECTRICITY
 from custom_components.red_energy.sensor import (
     RedEnergyBillingPeriodServiceChargeSensor,
+    RedEnergyCurrentPeriodDemandChargeSensor,
 )
 
 SUPPLY_CHARGE_RATE = {
@@ -568,6 +569,124 @@ class TestBillingPeriodServiceChargeSensor:
         assert sensor.last_reset is None
 
 
+class TestCurrentPeriodDemandChargeSensor:
+    def test_native_value_and_attributes(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[{"date": "2026-01-18", "import_usage": 10.0, "max_demand_kw": 4.608}],
+            last_bill_date="2026-01-01",
+            plan_name="Residential Demand Solar",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            sensor = RedEnergyCurrentPeriodDemandChargeSensor(
+                coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+            )
+            assert sensor.native_value == pytest.approx(round(4.608 * 0.253 * 17, 2))
+            assert sensor.device_class == SensorDeviceClass.MONETARY
+            assert sensor.native_unit_of_measurement == "AUD"
+            assert sensor.state_class == SensorStateClass.TOTAL
+            assert sensor._attr_name == "Current Period Demand Charge"
+            assert sensor._attr_unique_id.endswith("_current_period_demand_charge")
+
+            attrs = sensor.extra_state_attributes
+        assert attrs == {
+            "max_demand_kw": 4.608,
+            "demand_rate_incl_gst": pytest.approx(0.253),
+            "demand_rate_desc": "Demand Summer",
+            "represented_day_count": 17,
+        }
+
+    def test_native_value_none_when_not_demand_plan(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[{"date": "2026-01-18", "import_usage": 10.0, "max_demand_kw": 4.608}],
+            last_bill_date="2026-01-01",
+            plan_name="Residential Time of Use",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            sensor = RedEnergyCurrentPeriodDemandChargeSensor(
+                coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+            )
+            assert sensor.native_value is None
+            assert sensor.extra_state_attributes is None
+
+    def test_native_value_none_when_no_resolvable_demand_rate(self, coordinator):
+        """Only a Non-Summer demand rate is present; resolving for a
+        Summer date must not fall back to guessing it."""
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE_NON_SUMMER],
+            usage_entries=[{"date": "2026-01-18", "import_usage": 10.0, "max_demand_kw": 4.608}],
+            last_bill_date="2026-01-01",
+            plan_name="Residential Demand Solar",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            sensor = RedEnergyCurrentPeriodDemandChargeSensor(
+                coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+            )
+            assert sensor.native_value is None
+            assert sensor.extra_state_attributes is None
+
+    def test_native_value_none_when_no_max_demand_data(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[{"date": "2026-01-18", "import_usage": 10.0}],  # no max_demand_kw
+            last_bill_date="2026-01-01",
+            plan_name="Residential Demand Solar",
+        )
+        with patch("custom_components.red_energy.coordinator.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 1, 18)
+            mock_dt.strptime = datetime.strptime
+            sensor = RedEnergyCurrentPeriodDemandChargeSensor(
+                coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+            )
+            assert sensor.native_value is None
+            assert sensor.extra_state_attributes is None
+
+    def test_electricity_only_flag(self):
+        assert RedEnergyCurrentPeriodDemandChargeSensor._electricity_only is True
+
+    def test_last_reset_matches_billing_period_start(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[{"date": "2026-01-18", "import_usage": 10.0, "max_demand_kw": 4.608}],
+            last_bill_date="2026-01-01",
+            plan_name="Residential Demand Solar",
+        )
+        sensor = RedEnergyCurrentPeriodDemandChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        # last_reset must match billing_period_start (lastBillDate + 1 day),
+        # since lastBillDate is the last day of the *previous* period, not
+        # the first day of the current one.
+        assert sensor.last_reset.date().isoformat() == "2026-01-02"
+
+    def test_last_reset_is_none_when_last_bill_date_missing(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+            usage_entries=[{"date": "2026-01-18", "import_usage": 10.0, "max_demand_kw": 4.608}],
+            plan_name="Residential Demand Solar",
+        )
+        sensor = RedEnergyCurrentPeriodDemandChargeSensor(
+            coordinator, _config_entry(), "2000002", SERVICE_TYPE_ELECTRICITY
+        )
+        # Without lastBillDate, last_reset must be None (stable), not a
+        # datetime.now()-based fallback that drifts on every poll and would
+        # reset HA's statistics accumulation each update.
+        assert sensor.last_reset is None
+
+
 from custom_components.red_energy.const import DOMAIN, CONF_ENABLE_ADVANCED_SENSORS, SERVICE_TYPE_GAS
 from custom_components.red_energy.sensor import async_setup_entry
 
@@ -669,3 +788,71 @@ async def test_service_charge_sensors_created_for_electricity_and_gas_when_advan
         e for e in added_entities if isinstance(e, RedEnergyBillingPeriodServiceChargeSensor)
     ]
     assert len(billing_charge_sensors) == 2
+
+
+@pytest.mark.asyncio
+async def test_demand_charge_sensor_not_created_when_advanced_disabled():
+    coordinator = _mock_coordinator_for_setup(
+        [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE]
+    )
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["2000002"],
+                "services": [SERVICE_TYPE_ELECTRICITY],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    demand_charge_sensors = [
+        e for e in added_entities
+        if isinstance(e, RedEnergyCurrentPeriodDemandChargeSensor)
+    ]
+    assert demand_charge_sensors == []
+
+
+@pytest.mark.asyncio
+async def test_demand_charge_sensor_created_only_for_electricity_when_advanced_enabled():
+    """Gas services must never get a demand charge sensor - only electricity
+    gets one, even when both electricity and gas are configured."""
+    coordinator = _mock_coordinator_for_setup(
+        [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+        service_type=SERVICE_TYPE_ELECTRICITY,
+    )
+    gas_coordinator_data = coordinator.data["usage_data"]["2000002"]["property"]["services"]
+    gas_coordinator_data.append({**gas_coordinator_data[0], "type": SERVICE_TYPE_GAS})
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "entry1"
+    config_entry.options = {CONF_ENABLE_ADVANCED_SENSORS: True}
+
+    hass = MagicMock()
+    hass.data = {
+        DOMAIN: {
+            "entry1": {
+                "coordinator": coordinator,
+                "selected_accounts": ["2000002"],
+                "services": [SERVICE_TYPE_ELECTRICITY, SERVICE_TYPE_GAS],
+            }
+        }
+    }
+
+    added_entities = []
+    async_add_entities = MagicMock(side_effect=lambda entities: added_entities.extend(entities))
+    await async_setup_entry(hass, config_entry, async_add_entities)
+
+    demand_charge_sensors = [
+        e for e in added_entities if isinstance(e, RedEnergyCurrentPeriodDemandChargeSensor)
+    ]
+    assert len(demand_charge_sensors) == 1
+    assert demand_charge_sensors[0]._service_type == SERVICE_TYPE_ELECTRICITY

--- a/tests/test_service_charge_sensors.py
+++ b/tests/test_service_charge_sensors.py
@@ -1,7 +1,7 @@
 """Tests for the Billing Period Service Charge sensor (issue #71)."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -48,6 +48,30 @@ DEMAND_CHARGE_RATE = {
     "unit_step_desc": None,
 }
 
+DEMAND_CHARGE_RATE_NON_SUMMER = {
+    "rate_code": "80008279798FC",
+    "rate_desc": "Demand Non Summer",
+    "rate_incl_gst_dollars": 0.253,
+    "type": "F",
+    "rate_excl_gst_cents": 23,
+    "discounted_rate_excl_gst_in_cents": 23,
+    "discounted_rate_incl_gst_in_cents": 25.3,
+    "unit": "KW/day",
+    "unit_step_desc": None,
+}
+
+DEMAND_CHARGE_RATE_TEMPERATE = {
+    "rate_code": "80008279798FD",
+    "rate_desc": "Demand Temperate Peak",
+    "rate_incl_gst_dollars": 0.154,
+    "type": "F",
+    "rate_excl_gst_cents": 14,
+    "discounted_rate_excl_gst_in_cents": 14,
+    "discounted_rate_incl_gst_in_cents": 15.4,
+    "unit": "KW/day",
+    "unit_step_desc": None,
+}
+
 SECOND_SUPPLY_CHARGE_RATE = {
     "rate_code": "80008279798F2",
     "rate_desc": "Second Service To Property",
@@ -86,7 +110,7 @@ def coordinator(mock_hass):
     return coord
 
 
-def _set_coordinator_data(coordinator, rates, usage_entries=None, last_bill_date=None):
+def _set_coordinator_data(coordinator, rates, usage_entries=None, last_bill_date=None, plan_name=None):
     """Build coordinator.data with both the property.services (metadata/rates)
     and top-level services (usage) shapes get_service_metadata/get_service_usage expect."""
     service_metadata = {
@@ -97,6 +121,8 @@ def _set_coordinator_data(coordinator, rates, usage_entries=None, last_bill_date
     }
     if last_bill_date is not None:
         service_metadata["lastBillDate"] = last_bill_date
+    if plan_name is not None:
+        service_metadata["planName"] = plan_name
 
     services_usage = {}
     if usage_entries is not None:
@@ -173,6 +199,122 @@ class TestFindServiceChargeRate:
         rate = {**SUPPLY_CHARGE_RATE, "unit": None}
         _set_coordinator_data(coordinator, [rate])
         assert coordinator._find_service_charge_rate("2000002", SERVICE_TYPE_ELECTRICITY) is None
+
+
+class TestIsDemandPlan:
+    def test_true_when_plan_name_contains_demand(self, coordinator):
+        _set_coordinator_data(coordinator, [], plan_name="Residential Demand Solar")
+        assert coordinator._is_demand_plan("2000002", SERVICE_TYPE_ELECTRICITY) is True
+
+    def test_false_when_plan_name_has_no_demand(self, coordinator):
+        _set_coordinator_data(coordinator, [], plan_name="Residential Time of Use")
+        assert coordinator._is_demand_plan("2000002", SERVICE_TYPE_ELECTRICITY) is False
+
+    def test_false_when_plan_name_missing(self, coordinator):
+        """A missing/None planName must return False, never True - unknown
+        must never be treated as "yes, add a demand charge.\""""
+        _set_coordinator_data(coordinator, [])
+        assert coordinator._is_demand_plan("2000002", SERVICE_TYPE_ELECTRICITY) is False
+
+    def test_case_insensitive(self, coordinator):
+        _set_coordinator_data(coordinator, [], plan_name="RESIDENTIAL DEMAND SOLAR")
+        assert coordinator._is_demand_plan("2000002", SERVICE_TYPE_ELECTRICITY) is True
+
+
+class TestGetDemandRate:
+    def test_selects_summer_in_january(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+        )
+        rate = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY, on_date=date(2026, 1, 15))
+        assert rate["rate_desc"] == "Demand Summer"
+
+    def test_selects_summer_in_december(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+        )
+        rate = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY, on_date=date(2026, 12, 1))
+        assert rate["rate_desc"] == "Demand Summer"
+
+    def test_boundary_nov_1_is_summer(self, coordinator):
+        """Summer runs 1 Nov - 31 Mar, wrapping the year boundary - Nov 1
+        is the first day of Summer, not still Temperate."""
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+        )
+        rate = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY, on_date=date(2026, 11, 1))
+        assert rate["rate_desc"] == "Demand Summer"
+
+    def test_boundary_oct_31_is_temperate(self, coordinator):
+        """The day immediately before the Nov 1 Summer boundary must still
+        resolve to Temperate, not Summer."""
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+        )
+        rate = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY, on_date=date(2026, 10, 31))
+        assert rate["rate_desc"] == "Demand Temperate Peak"
+
+    def test_selects_non_summer_in_july(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+        )
+        rate = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY, on_date=date(2026, 7, 15))
+        assert rate["rate_desc"] == "Demand Non Summer"
+
+    def test_selects_temperate_in_april(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+        )
+        rate = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY, on_date=date(2026, 4, 15))
+        assert rate["rate_desc"] == "Demand Temperate Peak"
+
+    def test_selects_temperate_in_september(self, coordinator):
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+        )
+        rate = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY, on_date=date(2026, 9, 30))
+        assert rate["rate_desc"] == "Demand Temperate Peak"
+
+    def test_returns_none_when_no_demand_rates(self, coordinator):
+        _set_coordinator_data(coordinator, [ENERGY_RATE, SUPPLY_CHARGE_RATE])
+        rate = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY, on_date=date(2026, 1, 15))
+        assert rate is None
+
+    def test_returns_none_when_season_label_has_zero_matches(self, coordinator):
+        """Plan only has a Summer demand rate; resolving for a Non-Summer
+        date must not fall back to guessing the Summer rate."""
+        _set_coordinator_data(coordinator, [DEMAND_CHARGE_RATE])
+        rate = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY, on_date=date(2026, 7, 15))
+        assert rate is None
+
+    def test_returns_none_when_season_label_ambiguous(self, coordinator):
+        """Two rates share the same normalized rate_desc for the resolved
+        season - must never guess which one applies."""
+        duplicate_summer_rate = {**DEMAND_CHARGE_RATE, "rate_code": "80008279798FE", "rate_incl_gst_dollars": 0.30}
+        _set_coordinator_data(coordinator, [DEMAND_CHARGE_RATE, duplicate_summer_rate])
+        rate = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY, on_date=date(2026, 1, 15))
+        assert rate is None
+
+    def test_defaults_to_today_when_on_date_omitted(self, coordinator):
+        """on_date defaults to datetime.now().date() - verify by using
+        today's actual season rather than hardcoding an assumption about
+        the current date."""
+        _set_coordinator_data(
+            coordinator,
+            [DEMAND_CHARGE_RATE, DEMAND_CHARGE_RATE_NON_SUMMER, DEMAND_CHARGE_RATE_TEMPERATE],
+        )
+        expected = coordinator._get_demand_rate(
+            "2000002", SERVICE_TYPE_ELECTRICITY, on_date=datetime.now().date()
+        )
+        actual = coordinator._get_demand_rate("2000002", SERVICE_TYPE_ELECTRICITY)
+        assert actual == expected
 
 
 class TestGetBillingPeriodServiceCharge:


### PR DESCRIPTION
## Summary
- Fix "Projected Charges" undercounting bills on Demand-tariff electricity plans by ~$35/month — the demand charge (based on max 30-minute demand in the billing period) was entirely missing from the calculation
- Add `_is_demand_plan()`/`_get_demand_rate()` coordinator helpers: detect a Demand-tariff plan via `currentPlan.planName` containing "demand", resolve the seasonally-applicable demand rate ("Demand Summer"/"Demand Non Summer"/"Demand Temperate Peak")
- Add demand charge to both the accrued-to-date and projected billing calculations, additive and gated on Demand plans only — Time-of-Use plan calculations are unchanged
- Add new "Current Period Demand Charge" sensor (accrued-to-date figure, mirrors the existing "Current Period Service Charge" sensor)
- Expose `estimated_demand_charge`/`demand_rate_incl_gst` as attributes on the "Projected Charges" sensor for Demand-plan accounts
- Update README.md and CLAUDE.md sensor documentation

## Notes
- Seasonal rate windows are hardcoded per Red Energy's published structure: Summer 1 Nov–31 Mar, Non-Summer 1 Jun–31 Aug, Temperate 1 Apr–31 May & 1 Sep–31 Oct
- The demand-charge projection extrapolates today's max observed demand across the remaining billing cycle — a documented approximation, same linear-extrapolation approach already used for the energy-cost projection
- No config-entry migration needed — no sensor_type/unique_id renamed
- Version bumped 1.20.0 → 1.21.0 (MINOR, new sensor)